### PR TITLE
feat: continuous deployment on github pages

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,30 @@
+name: Sec-o-simple Website
+
+on:
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  contents: write
+  pages: write
+  actions: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run build
+      - name: Deploy to GitHub Pages
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v4
+        with:
+          target_branch: gh-pages
+          build_dir: dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# CD on Github pages

for this to work we need an access token for our [Github Pages](https://github.com/sec-o-simple/sec-o-simple.github.io) repository, but I don't think I have the necessary permissions for this.
@tschmidtb51 could you please try to create one?