### PR TITLE
feat: Add validation and error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ git clone git@github.com:sec-o-simple/sec-o-simple.git
 cd sec-o-simple
 
 # Install NPM dependencies
-npm ci
+npm install
 ```
 
 ### Run server

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@heroui/table": "^2.2.12",
         "@heroui/tabs": "^2.2.11",
         "@heroui/theme": "^2.4.9",
+        "@secvisogram/csaf-validator-lib": "^1.3.50",
         "motion": "^12.4.7",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -593,6 +594,15 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
@@ -2488,6 +2498,21 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-joda/core": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.5.tgz",
+      "integrity": "sha512-3zwefSMwHpu8iVUW8YYz227sIv6UFqO31p1Bf1ZH/Vom7CmNyUsXjDBlnNzcuhmOL1XfxZ3nvND42kR23XlbcQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@js-joda/timezone": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@js-joda/timezone/-/timezone-2.22.0.tgz",
+      "integrity": "sha512-9UNXxEztbcofD6XvV7xPrbzB2nE/AWaHr/XfugRZgVqg2vCZOVPnD8QI7GW164EFIWMw0c97Gs6STJ5dh0J99Q==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "@js-joda/core": ">=1.11.0"
       }
     },
     "node_modules/@lukeed/csprng": {
@@ -4442,6 +4467,47 @@
         "win32"
       ]
     },
+    "node_modules/@secvisogram/csaf-validator-lib": {
+      "version": "1.3.50",
+      "resolved": "https://registry.npmjs.org/@secvisogram/csaf-validator-lib/-/csaf-validator-lib-1.3.50.tgz",
+      "integrity": "sha512-V6l1WCPyLJTvn6uAoQSiIKHq7P2OFEk3oVTO6j19IonlXdw9M6Po+B58kBnKRusg6jWYQQHf8Z4mUXjZkcSvng==",
+      "license": "MIT",
+      "dependencies": {
+        "@js-joda/core": "^5.6.1",
+        "@js-joda/timezone": "^2.18.2",
+        "ajv": "^8.11.2",
+        "ajv-formats": "^2.1.1",
+        "bcp47": "^1.1.2",
+        "cvss2js": "^1.1.0",
+        "json-pointer": "^0.6.1",
+        "lodash": "^4.17.21",
+        "packageurl-js": "^2.0.1",
+        "semver": "^7.5.4",
+        "undici": "^5.27.0"
+      }
+    },
+    "node_modules/@secvisogram/csaf-validator-lib/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@secvisogram/csaf-validator-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/@swc/core": {
       "version": "1.11.16",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.16.tgz",
@@ -5098,6 +5164,45 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -5518,6 +5623,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bcp47": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/bcp47/-/bcp47-1.1.2.tgz",
+      "integrity": "sha512-JnkkL4GUpOvvanH9AZPX38CxhiLsXMBicBY2IAtqiVN8YulGDQybUydWA4W6yAMtw6iShtw+8HEF6cfrTHU+UQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -6044,6 +6158,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/cvss2js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cvss2js/-/cvss2js-1.1.0.tgz",
+      "integrity": "sha512-ssH3uw7jcxZgp1rbsUoYUbVlvQghAgPKDUQafapMhNvr4N/MvrXr217KOTHJZHDjT6hxOlOqvCLbC/JxL1T8Tg==",
       "license": "MIT"
     },
     "node_modules/cypress": {
@@ -7131,7 +7251,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -7182,6 +7301,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -7316,6 +7451,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/foreach": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
+      "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==",
+      "license": "MIT"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -8521,6 +8662,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-pointer": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
+      "integrity": "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==",
+      "license": "MIT",
+      "dependencies": {
+        "foreach": "^2.0.4"
+      }
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -8704,7 +8854,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -9307,6 +9456,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/packageurl-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-2.0.1.tgz",
+      "integrity": "sha512-N5ixXjzTy4QDQH0Q9YFjqIWd6zH6936Djpl2m9QNFmDv5Fum8q8BjkpAcHNMzOFE0IwQrFhJWex3AN6kS0OSwg==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9886,6 +10041,15 @@
         "throttleit": "^1.0.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -10142,7 +10306,6 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11064,6 +11227,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@heroui/table": "^2.2.12",
     "@heroui/tabs": "^2.2.11",
     "@heroui/theme": "^2.4.9",
+    "@secvisogram/csaf-validator-lib": "^1.3.50",
     "motion": "^12.4.7",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/src/components/forms/ComponentList.tsx
+++ b/src/components/forms/ComponentList.tsx
@@ -15,7 +15,7 @@ export type ComponentListProps<T> = {
   listState: ListState<T>
   title: DynamicObjectValueKey<T>
   /** Generator function for a ReactNode that will be shown when an item is expanded */
-  content: (item: T) => ReactNode
+  content: (item: T, index: number) => ReactNode
   onChange?: (updatedItems: T[]) => void
   onDelete?: (item: T) => void
   startContent?: (item: T) => ReactNode
@@ -47,7 +47,7 @@ export default function ComponentList<T extends object>({
         }}
         className="px-0"
       >
-        {listState.data.map((item) => (
+        {listState.data.map((item, index) => (
           <AccordionItem
             key={listState.getId(item)}
             startContent={
@@ -72,7 +72,7 @@ export default function ComponentList<T extends object>({
               </div>
             }
           >
-            {content(item)}
+            {content(item, index)}
           </AccordionItem>
         ))}
       </Accordion>

--- a/src/components/forms/Input.tsx
+++ b/src/components/forms/Input.tsx
@@ -1,3 +1,5 @@
+import { useDebounceInput } from '@/utils/useDebounceInput'
+import { useFieldValidation } from '@/utils/useFieldValidation'
 import {
   Input as HeroUIInput,
   Textarea as HeroUITextarea,
@@ -5,8 +7,21 @@ import {
   TextAreaProps,
 } from '@heroui/input'
 
-export function Input(props: InputProps) {
-  const { placeholder, labelPlacement, variant, ...rest } = props
+export function Input(props: InputProps & { csafPath?: string }) {
+  const { placeholder, labelPlacement, variant, csafPath, onBlur, onChange, value: propValue, ...rest } = props
+  const validation = useFieldValidation(csafPath)
+
+  const {
+    value: debouncedValue,
+    isDebouncing,
+    handleBlur,
+    handleChange
+  } = useDebounceInput({
+    onChange,
+    onBlur,
+    value: propValue,
+  })
+
   return (
     <HeroUIInput
       variant={variant ?? 'bordered'}
@@ -15,13 +30,35 @@ export function Input(props: InputProps) {
       classNames={{
         inputWrapper: 'border-1 shadow-none',
       }}
+      value={debouncedValue}
+      errorMessage={validation.errorMessages.map(m => m.message).join(', ')}
+      isInvalid={!isDebouncing && validation.hasErrors && (validation.isTouched || !!propValue?.length)}
+      onBlur={(e) => {
+        if (csafPath) {
+          validation.markFieldAsTouched(csafPath)
+        }
+        handleBlur(e)
+      }}
+      onChange={handleChange}
       {...rest}
     />
   )
 }
 
-export function Textarea(props: TextAreaProps) {
-  const { placeholder, labelPlacement, variant, ...rest } = props
+export function Textarea(props: TextAreaProps & { csafPath?: string }) {
+  const { placeholder, labelPlacement, variant, csafPath, onBlur, onChange, value: propValue, ...rest } = props
+  const validation = useFieldValidation(csafPath)
+  const {
+    value: debouncedValue,
+    isDebouncing,
+    handleBlur,
+    handleChange
+  } = useDebounceInput({
+    onChange,
+    onBlur,
+    value: propValue,
+  })
+
   return (
     <HeroUITextarea
       variant={variant ?? 'bordered'}
@@ -30,6 +67,16 @@ export function Textarea(props: TextAreaProps) {
       classNames={{
         inputWrapper: 'border-1 shadow-none',
       }}
+      value={debouncedValue}
+      errorMessage={validation.errorMessages.map(m => m.message).join(', ')}
+      isInvalid={!isDebouncing && validation.hasErrors && validation.isTouched}
+      onBlur={(e) => {
+        if (csafPath) {
+          validation.markFieldAsTouched(csafPath)
+        }
+        handleBlur(e)
+      }}
+      onChange={handleChange}
       {...rest}
     />
   )

--- a/src/components/forms/Input.tsx
+++ b/src/components/forms/Input.tsx
@@ -15,6 +15,7 @@ export function Input(props: InputProps & { csafPath?: string }) {
     csafPath,
     onBlur,
     onChange,
+    onValueChange,
     value: propValue,
     ...rest
   } = props
@@ -26,7 +27,10 @@ export function Input(props: InputProps & { csafPath?: string }) {
     handleBlur,
     handleChange,
   } = useDebounceInput({
-    onChange,
+    onChange: (e) => {
+      onValueChange?.(e.target.value)
+      onChange?.(e)
+    },
     onBlur,
     value: propValue,
   })
@@ -66,6 +70,7 @@ export function Textarea(props: TextAreaProps & { csafPath?: string }) {
     csafPath,
     onBlur,
     onChange,
+    onValueChange,
     value: propValue,
     ...rest
   } = props
@@ -76,7 +81,10 @@ export function Textarea(props: TextAreaProps & { csafPath?: string }) {
     handleBlur,
     handleChange,
   } = useDebounceInput({
-    onChange,
+    onChange: (e) => {
+      onValueChange?.(e.target.value)
+      onChange?.(e)
+    },
     onBlur,
     value: propValue,
   })

--- a/src/components/forms/Input.tsx
+++ b/src/components/forms/Input.tsx
@@ -7,7 +7,9 @@ import {
   TextAreaProps,
 } from '@heroui/input'
 
-export function Input(props: InputProps & { csafPath?: string, isTouched?: boolean }) {
+export function Input(
+  props: InputProps & { csafPath?: string; isTouched?: boolean },
+) {
   const {
     placeholder,
     labelPlacement,
@@ -63,7 +65,9 @@ export function Input(props: InputProps & { csafPath?: string, isTouched?: boole
   )
 }
 
-export function Textarea(props: TextAreaProps & { csafPath?: string, isTouched?: boolean }) {
+export function Textarea(
+  props: TextAreaProps & { csafPath?: string; isTouched?: boolean },
+) {
   const {
     placeholder,
     labelPlacement,
@@ -101,7 +105,11 @@ export function Textarea(props: TextAreaProps & { csafPath?: string, isTouched?:
       }}
       value={debouncedValue}
       errorMessage={validation.errorMessages.map((m) => m.message).join(', ')}
-      isInvalid={!isDebouncing && validation.hasErrors && (validation.isTouched || isTouched)}
+      isInvalid={
+        !isDebouncing &&
+        validation.hasErrors &&
+        (validation.isTouched || isTouched)
+      }
       onBlur={(e) => {
         if (csafPath) {
           validation.markFieldAsTouched(csafPath)

--- a/src/components/forms/Input.tsx
+++ b/src/components/forms/Input.tsx
@@ -7,12 +7,13 @@ import {
   TextAreaProps,
 } from '@heroui/input'
 
-export function Input(props: InputProps & { csafPath?: string }) {
+export function Input(props: InputProps & { csafPath?: string, isTouched?: boolean }) {
   const {
     placeholder,
     labelPlacement,
     variant,
     csafPath,
+    isTouched,
     onBlur,
     onChange,
     onValueChange,
@@ -48,7 +49,7 @@ export function Input(props: InputProps & { csafPath?: string }) {
       isInvalid={
         !isDebouncing &&
         validation.hasErrors &&
-        (validation.isTouched || !!propValue?.length)
+        (isTouched || validation.isTouched || !!propValue?.length)
       }
       onBlur={(e) => {
         if (csafPath) {
@@ -62,12 +63,13 @@ export function Input(props: InputProps & { csafPath?: string }) {
   )
 }
 
-export function Textarea(props: TextAreaProps & { csafPath?: string }) {
+export function Textarea(props: TextAreaProps & { csafPath?: string, isTouched?: boolean }) {
   const {
     placeholder,
     labelPlacement,
     variant,
     csafPath,
+    isTouched,
     onBlur,
     onChange,
     onValueChange,
@@ -99,7 +101,7 @@ export function Textarea(props: TextAreaProps & { csafPath?: string }) {
       }}
       value={debouncedValue}
       errorMessage={validation.errorMessages.map((m) => m.message).join(', ')}
-      isInvalid={!isDebouncing && validation.hasErrors && validation.isTouched}
+      isInvalid={!isDebouncing && validation.hasErrors && (validation.isTouched || isTouched)}
       onBlur={(e) => {
         if (csafPath) {
           validation.markFieldAsTouched(csafPath)

--- a/src/components/forms/Input.tsx
+++ b/src/components/forms/Input.tsx
@@ -8,14 +8,23 @@ import {
 } from '@heroui/input'
 
 export function Input(props: InputProps & { csafPath?: string }) {
-  const { placeholder, labelPlacement, variant, csafPath, onBlur, onChange, value: propValue, ...rest } = props
+  const {
+    placeholder,
+    labelPlacement,
+    variant,
+    csafPath,
+    onBlur,
+    onChange,
+    value: propValue,
+    ...rest
+  } = props
   const validation = useFieldValidation(csafPath)
 
   const {
     value: debouncedValue,
     isDebouncing,
     handleBlur,
-    handleChange
+    handleChange,
   } = useDebounceInput({
     onChange,
     onBlur,
@@ -31,8 +40,12 @@ export function Input(props: InputProps & { csafPath?: string }) {
         inputWrapper: 'border-1 shadow-none',
       }}
       value={debouncedValue}
-      errorMessage={validation.errorMessages.map(m => m.message).join(', ')}
-      isInvalid={!isDebouncing && validation.hasErrors && (validation.isTouched || !!propValue?.length)}
+      errorMessage={validation.errorMessages.map((m) => m.message).join(', ')}
+      isInvalid={
+        !isDebouncing &&
+        validation.hasErrors &&
+        (validation.isTouched || !!propValue?.length)
+      }
       onBlur={(e) => {
         if (csafPath) {
           validation.markFieldAsTouched(csafPath)
@@ -46,13 +59,22 @@ export function Input(props: InputProps & { csafPath?: string }) {
 }
 
 export function Textarea(props: TextAreaProps & { csafPath?: string }) {
-  const { placeholder, labelPlacement, variant, csafPath, onBlur, onChange, value: propValue, ...rest } = props
+  const {
+    placeholder,
+    labelPlacement,
+    variant,
+    csafPath,
+    onBlur,
+    onChange,
+    value: propValue,
+    ...rest
+  } = props
   const validation = useFieldValidation(csafPath)
   const {
     value: debouncedValue,
     isDebouncing,
     handleBlur,
-    handleChange
+    handleChange,
   } = useDebounceInput({
     onChange,
     onBlur,
@@ -68,7 +90,7 @@ export function Textarea(props: TextAreaProps & { csafPath?: string }) {
         inputWrapper: 'border-1 shadow-none',
       }}
       value={debouncedValue}
-      errorMessage={validation.errorMessages.map(m => m.message).join(', ')}
+      errorMessage={validation.errorMessages.map((m) => m.message).join(', ')}
       isInvalid={!isDebouncing && validation.hasErrors && validation.isTouched}
       onBlur={(e) => {
         if (csafPath) {

--- a/src/components/forms/Select.tsx
+++ b/src/components/forms/Select.tsx
@@ -1,8 +1,8 @@
 import { useFieldValidation } from '@/utils/useFieldValidation'
 import { Select as HeroUISelect, SelectProps } from '@heroui/select'
 
-export default function Select(props: SelectProps & { csafPath?: string }) {
-  const { placeholder, labelPlacement, variant, csafPath, onChange, ...rest } =
+export default function Select(props: SelectProps & { csafPath?: string, isTouched?: boolean }) {
+  const { placeholder, labelPlacement, variant, csafPath, isTouched, onChange, ...rest } =
     props
   const validation = useFieldValidation(csafPath)
 
@@ -24,7 +24,7 @@ export default function Select(props: SelectProps & { csafPath?: string }) {
       }}
       onChange={handleChange}
       errorMessage={validation.errorMessages.map((m) => m.message).join(', ')}
-      isInvalid={validation.hasErrors && validation.isTouched}
+      isInvalid={validation.hasErrors && (isTouched || validation.isTouched)}
       {...rest}
     />
   )

--- a/src/components/forms/Select.tsx
+++ b/src/components/forms/Select.tsx
@@ -2,7 +2,8 @@ import { useFieldValidation } from '@/utils/useFieldValidation'
 import { Select as HeroUISelect, SelectProps } from '@heroui/select'
 
 export default function Select(props: SelectProps & { csafPath?: string }) {
-  const { placeholder, labelPlacement, variant, csafPath, onChange, ...rest } = props
+  const { placeholder, labelPlacement, variant, csafPath, onChange, ...rest } =
+    props
   const validation = useFieldValidation(csafPath)
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -12,7 +13,7 @@ export default function Select(props: SelectProps & { csafPath?: string }) {
     }
     onChange?.(e)
   }
-  
+
   return (
     <HeroUISelect
       labelPlacement={labelPlacement ?? 'outside'}
@@ -22,7 +23,7 @@ export default function Select(props: SelectProps & { csafPath?: string }) {
         trigger: 'border-1 shadow-none',
       }}
       onChange={handleChange}
-      errorMessage={validation.errorMessages.map(m => m.message).join(', ')}
+      errorMessage={validation.errorMessages.map((m) => m.message).join(', ')}
       isInvalid={validation.hasErrors && validation.isTouched}
       {...rest}
     />

--- a/src/components/forms/Select.tsx
+++ b/src/components/forms/Select.tsx
@@ -1,9 +1,18 @@
 import { useFieldValidation } from '@/utils/useFieldValidation'
 import { Select as HeroUISelect, SelectProps } from '@heroui/select'
 
-export default function Select(props: SelectProps & { csafPath?: string, isTouched?: boolean }) {
-  const { placeholder, labelPlacement, variant, csafPath, isTouched, onChange, ...rest } =
-    props
+export default function Select(
+  props: SelectProps & { csafPath?: string; isTouched?: boolean },
+) {
+  const {
+    placeholder,
+    labelPlacement,
+    variant,
+    csafPath,
+    isTouched,
+    onChange,
+    ...rest
+  } = props
   const validation = useFieldValidation(csafPath)
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {

--- a/src/components/forms/Select.tsx
+++ b/src/components/forms/Select.tsx
@@ -1,7 +1,18 @@
+import { useFieldValidation } from '@/utils/useFieldValidation'
 import { Select as HeroUISelect, SelectProps } from '@heroui/select'
 
-export default function Select(props: SelectProps) {
-  const { placeholder, labelPlacement, variant, ...rest } = props
+export default function Select(props: SelectProps & { csafPath?: string }) {
+  const { placeholder, labelPlacement, variant, csafPath, onChange, ...rest } = props
+  const validation = useFieldValidation(csafPath)
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (csafPath) {
+      // Only after touching the field, we want to show errors.
+      validation.markFieldAsTouched(csafPath)
+    }
+    onChange?.(e)
+  }
+  
   return (
     <HeroUISelect
       labelPlacement={labelPlacement ?? 'outside'}
@@ -10,6 +21,9 @@ export default function Select(props: SelectProps) {
       classNames={{
         trigger: 'border-1 shadow-none',
       }}
+      onChange={handleChange}
+      errorMessage={validation.errorMessages.map(m => m.message).join(', ')}
+      isInvalid={validation.hasErrors && validation.isTouched}
       {...rest}
     />
   )

--- a/src/components/layout/NavigationLayout.tsx
+++ b/src/components/layout/NavigationLayout.tsx
@@ -52,12 +52,14 @@ function Section({
     <div className="flex flex-col gap-2 text-neutral-foreground">
       <NavLink
         to={to}
-        className={`flex cursor-pointer items-center gap-2 rounded-lg p-2 transition-colors hover:bg-content2 ${isActive ? 'bg-content2 font-semibold text-foreground' : ''
-          }`}
+        className={`flex cursor-pointer items-center gap-2 rounded-lg p-2 transition-colors hover:bg-content2 ${
+          isActive ? 'bg-content2 font-semibold text-foreground' : ''
+        }`}
       >
         <div
-          className={`flex size-8 items-center justify-center rounded-full bg-content3 p-4 ${isActive ? 'bg-primary text-primary-foreground' : ''
-            }`}
+          className={`flex size-8 items-center justify-center rounded-full bg-content3 p-4 ${
+            isActive ? 'bg-primary text-primary-foreground' : ''
+          }`}
         >
           {number}
         </div>
@@ -71,15 +73,25 @@ function Section({
   )
 }
 
-function StatusIndicator({ hasErrors, hasVisited }: { hasErrors: boolean, hasVisited: boolean }) {
+function StatusIndicator({
+  hasErrors,
+  hasVisited,
+}: {
+  hasErrors: boolean
+  hasVisited: boolean
+}) {
   return (
     <div
-      className={`size-2 rounded-full ${hasVisited ? hasErrors ? 'bg-red-400' : 'bg-green-500' : 'bg-neutral-300'
-        }`}
+      className={`size-2 rounded-full ${
+        hasVisited
+          ? hasErrors
+            ? 'bg-red-400'
+            : 'bg-green-500'
+          : 'bg-neutral-300'
+      }`}
     />
   )
 }
-
 
 function SubSection({ title, to }: { title: string; to: string }) {
   const pathValidation = usePathValidation(to)
@@ -88,7 +100,8 @@ function SubSection({ title, to }: { title: string; to: string }) {
     <NavLink
       to={to}
       className={({ isActive }) =>
-        `flex items-center gap-2 cursor-pointer pl-12 transition-colors hover:text-primary ${isActive ? 'text-primary' : ''
+        `flex items-center gap-2 cursor-pointer pl-12 transition-colors hover:text-primary ${
+          isActive ? 'text-primary' : ''
         }`
       }
     >

--- a/src/components/layout/NavigationLayout.tsx
+++ b/src/components/layout/NavigationLayout.tsx
@@ -1,3 +1,5 @@
+import { usePathValidation } from '@/utils/usePathValidation'
+import React from 'react'
 import { PropsWithChildren, useMemo } from 'react'
 import { NavLink, Outlet, useLocation } from 'react-router'
 
@@ -44,21 +46,24 @@ function Section({
     [location.pathname, to],
   )
 
+  const pathValidation = usePathValidation(to)
+
   return (
     <div className="flex flex-col gap-2 text-neutral-foreground">
       <NavLink
         to={to}
-        className={`flex cursor-pointer items-center gap-2 rounded-lg p-2 transition-colors hover:bg-content2 ${
-          isActive ? 'bg-content2 font-semibold text-foreground' : ''
-        }`}
+        className={`flex cursor-pointer items-center gap-2 rounded-lg p-2 transition-colors hover:bg-content2 ${isActive ? 'bg-content2 font-semibold text-foreground' : ''
+          }`}
       >
         <div
-          className={`flex size-8 items-center justify-center rounded-full bg-content3 p-4 ${
-            isActive ? 'bg-primary text-primary-foreground' : ''
-          }`}
+          className={`flex size-8 items-center justify-center rounded-full bg-content3 p-4 ${isActive ? 'bg-primary text-primary-foreground' : ''
+            }`}
         >
           {number}
         </div>
+        {React.Children.count(children) === 0 && (
+          <StatusIndicator {...pathValidation} />
+        )}
         {title}
       </NavLink>
       {children}
@@ -66,16 +71,28 @@ function Section({
   )
 }
 
+function StatusIndicator({ hasErrors, hasVisited }: { hasErrors: boolean, hasVisited: boolean }) {
+  return (
+    <div
+      className={`size-2 rounded-full ${hasVisited ? hasErrors ? 'bg-red-400' : 'bg-green-500' : 'bg-neutral-300'
+        }`}
+    />
+  )
+}
+
+
 function SubSection({ title, to }: { title: string; to: string }) {
+  const pathValidation = usePathValidation(to)
+
   return (
     <NavLink
       to={to}
       className={({ isActive }) =>
-        `cursor-pointer pl-12 transition-colors hover:text-primary ${
-          isActive ? 'text-primary' : ''
+        `flex items-center gap-2 cursor-pointer pl-12 transition-colors hover:text-primary ${isActive ? 'text-primary' : ''
         }`
       }
     >
+      <StatusIndicator {...pathValidation} />
       {title}
     </NavLink>
   )

--- a/src/components/layout/TopBarLayout.tsx
+++ b/src/components/layout/TopBarLayout.tsx
@@ -43,7 +43,11 @@ export default function TopBarLayout() {
             <FontAwesomeIcon icon={faSave} />
             Save Draft
           </Button>
-          <Button color="primary" onPress={exportCSAFDocument} isDisabled={!isValid || isValidating}>
+          <Button
+            color="primary"
+            onPress={exportCSAFDocument}
+            isDisabled={!isValid || isValidating}
+          >
             <FontAwesomeIcon icon={faFileExport} />
             Export
           </Button>

--- a/src/components/layout/TopBarLayout.tsx
+++ b/src/components/layout/TopBarLayout.tsx
@@ -44,7 +44,10 @@ export default function TopBarLayout() {
             <FontAwesomeIcon icon={faSave} />
             Save Draft
           </Button>
-          <Tooltip content="There are some errors in the document. Please fix them before exporting." isDisabled={isValid && !isValidating}>
+          <Tooltip
+            content="There are some errors in the document. Please fix them before exporting."
+            isDisabled={isValid && !isValidating}
+          >
             <div>
               <Button
                 color="primary"

--- a/src/components/layout/TopBarLayout.tsx
+++ b/src/components/layout/TopBarLayout.tsx
@@ -1,4 +1,5 @@
 import { useCSAFExport } from '@/utils/csafExport/csafExport'
+import useValidationStore from '@/utils/useValidationStore'
 import {
   faAdd,
   faEye,
@@ -13,6 +14,7 @@ import { Outlet, useNavigate } from 'react-router'
 export default function TopBarLayout() {
   const navigate = useNavigate()
   const { exportCSAFDocument } = useCSAFExport()
+  const { isValid, isValidating } = useValidationStore()
 
   return (
     <div className="flex h-screen flex-col">
@@ -41,7 +43,7 @@ export default function TopBarLayout() {
             <FontAwesomeIcon icon={faSave} />
             Save Draft
           </Button>
-          <Button color="primary" onPress={exportCSAFDocument}>
+          <Button color="primary" onPress={exportCSAFDocument} isDisabled={!isValid || isValidating}>
             <FontAwesomeIcon icon={faFileExport} />
             Export
           </Button>

--- a/src/components/layout/TopBarLayout.tsx
+++ b/src/components/layout/TopBarLayout.tsx
@@ -9,6 +9,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button } from '@heroui/button'
+import { Tooltip } from '@heroui/react'
 import { Outlet, useNavigate } from 'react-router'
 
 export default function TopBarLayout() {
@@ -43,14 +44,18 @@ export default function TopBarLayout() {
             <FontAwesomeIcon icon={faSave} />
             Save Draft
           </Button>
-          <Button
-            color="primary"
-            onPress={exportCSAFDocument}
-            isDisabled={!isValid || isValidating}
-          >
-            <FontAwesomeIcon icon={faFileExport} />
-            Export
-          </Button>
+          <Tooltip content="There are some errors in the document. Please fix them before exporting." isDisabled={isValid && !isValidating}>
+            <div>
+              <Button
+                color="primary"
+                onPress={exportCSAFDocument}
+                isDisabled={!isValid || isValidating}
+              >
+                <FontAwesomeIcon icon={faFileExport} />
+                Export
+              </Button>
+            </div>
+          </Tooltip>
         </div>
       </div>
       <Outlet />

--- a/src/routes/document-information/General.tsx
+++ b/src/routes/document-information/General.tsx
@@ -11,6 +11,7 @@ import {
   getDefaultGeneralDocumentInformation,
 } from './types/tGeneralDocumentInformation'
 import { useTemplate } from '@/utils/template'
+import usePageVisit from '@/utils/usePageVisit'
 
 export default function General() {
   const [localState, setLocalState] = useState<TGeneralDocumentInformation>(
@@ -24,6 +25,7 @@ export default function General() {
     init: setLocalState,
   })
 
+  const hasVisitedPage = usePageVisit()
   const { isFieldReadonly } = useTemplate()
 
   return (
@@ -35,6 +37,7 @@ export default function General() {
       <Input
         label="Title"
         csafPath="/document/title"
+        isTouched={hasVisitedPage}
         value={localState.title}
         onValueChange={(title) => setLocalState({ ...localState, title })}
         isDisabled={isFieldReadonly('document-information.title')}
@@ -43,6 +46,7 @@ export default function General() {
         <Input
           label="ID"
           csafPath="/document/tracking/id"
+          isTouched={hasVisitedPage}
           value={localState.id}
           onValueChange={(id) => setLocalState({ ...localState, id })}
           isDisabled={isFieldReadonly('document-information.id')}
@@ -50,6 +54,7 @@ export default function General() {
         <Select
           label="Language"
           csafPath="/document/lang"
+          isTouched={hasVisitedPage}
           selectedKeys={[localState.language]}
           onSelectionChange={(v) =>
             setLocalState({ ...localState, language: [...v][0] as string })

--- a/src/routes/document-information/General.tsx
+++ b/src/routes/document-information/General.tsx
@@ -39,7 +39,7 @@ export default function General() {
         onValueChange={(title) => setLocalState({ ...localState, title })}
         isDisabled={isFieldReadonly('document-information.title')}
       />
-      <HSplit>
+      <HSplit className="items-start">
         <Input
           label="ID"
           csafPath="/document/tracking/id"

--- a/src/routes/document-information/General.tsx
+++ b/src/routes/document-information/General.tsx
@@ -34,6 +34,7 @@ export default function General() {
     >
       <Input
         label="Title"
+        csafPath="/document/title"
         value={localState.title}
         onValueChange={(title) => setLocalState({ ...localState, title })}
         isDisabled={isFieldReadonly('document-information.title')}
@@ -41,12 +42,14 @@ export default function General() {
       <HSplit>
         <Input
           label="ID"
+          csafPath="/document/tracking/id"
           value={localState.id}
           onValueChange={(id) => setLocalState({ ...localState, id })}
           isDisabled={isFieldReadonly('document-information.id')}
         />
         <Select
           label="Language"
+          csafPath="/document/lang"
           selectedKeys={[localState.language]}
           onSelectionChange={(v) =>
             setLocalState({ ...localState, language: [...v][0] as string })

--- a/src/routes/document-information/Notes.tsx
+++ b/src/routes/document-information/Notes.tsx
@@ -20,7 +20,10 @@ export default function Notes() {
   })
 
   const hasVisitedPage = usePageVisit()
-  const listValidation = useListValidation(`/document/notes`, notesListState.data)
+  const listValidation = useListValidation(
+    `/document/notes`,
+    notesListState.data,
+  )
 
   return (
     <WizardStep
@@ -29,15 +32,14 @@ export default function Notes() {
       onBack={'/document-information/general'}
       onContinue={'/document-information/publisher'}
     >
-      {(hasVisitedPage || listValidation.isTouched) && listValidation.hasErrors && (
-        <Alert color="danger">
-          {listValidation.errorMessages.map((m) => (
-            <p key={m.path}>
-              {m.message}
-            </p>
-          ))}
-        </Alert>
-      )}
+      {(hasVisitedPage || listValidation.isTouched) &&
+        listValidation.hasErrors && (
+          <Alert color="danger">
+            {listValidation.errorMessages.map((m) => (
+              <p key={m.path}>{m.message}</p>
+            ))}
+          </Alert>
+        )}
       <NotesList
         notesListState={notesListState}
         csafPath="/document/notes"

--- a/src/routes/document-information/Notes.tsx
+++ b/src/routes/document-information/Notes.tsx
@@ -3,6 +3,8 @@ import { useListState } from '@/utils/useListState'
 import { NoteGenerator, NotesList, TNote } from '../shared/NotesList'
 import useDocumentStoreUpdater from '@/utils/useDocumentStoreUpdater'
 import { TDocumentInformation } from './types/tDocumentInformation'
+import { Alert } from '@heroui/react'
+import { useListValidation } from '@/utils/useListValidation'
 
 export default function Notes() {
   const notesListState = useListState<TNote>({
@@ -16,6 +18,8 @@ export default function Notes() {
     init: (initialData) => notesListState.setData(initialData.notes),
   })
 
+  const listValidation = useListValidation(`/document/notes`, notesListState.data)
+
   return (
     <WizardStep
       title="Document Information - Notes"
@@ -23,7 +27,16 @@ export default function Notes() {
       onBack={'/document-information/general'}
       onContinue={'/document-information/publisher'}
     >
-      <NotesList notesListState={notesListState} />
+      {listValidation.isTouched && listValidation.hasErrors && (
+        <Alert color="danger">
+          {listValidation.errorMessages.map((m) => (
+            <p key={m.path}>
+              {m.message}
+            </p>
+          ))}
+        </Alert>
+      )}
+      <NotesList notesListState={notesListState} csafPath="/document/notes" />
     </WizardStep>
   )
 }

--- a/src/routes/document-information/Notes.tsx
+++ b/src/routes/document-information/Notes.tsx
@@ -5,6 +5,7 @@ import useDocumentStoreUpdater from '@/utils/useDocumentStoreUpdater'
 import { TDocumentInformation } from './types/tDocumentInformation'
 import { Alert } from '@heroui/react'
 import { useListValidation } from '@/utils/useListValidation'
+import usePageVisit from '@/utils/usePageVisit'
 
 export default function Notes() {
   const notesListState = useListState<TNote>({
@@ -18,6 +19,7 @@ export default function Notes() {
     init: (initialData) => notesListState.setData(initialData.notes),
   })
 
+  const hasVisitedPage = usePageVisit()
   const listValidation = useListValidation(`/document/notes`, notesListState.data)
 
   return (
@@ -27,7 +29,7 @@ export default function Notes() {
       onBack={'/document-information/general'}
       onContinue={'/document-information/publisher'}
     >
-      {listValidation.isTouched && listValidation.hasErrors && (
+      {(hasVisitedPage || listValidation.isTouched) && listValidation.hasErrors && (
         <Alert color="danger">
           {listValidation.errorMessages.map((m) => (
             <p key={m.path}>
@@ -36,7 +38,11 @@ export default function Notes() {
           ))}
         </Alert>
       )}
-      <NotesList notesListState={notesListState} csafPath="/document/notes" />
+      <NotesList
+        notesListState={notesListState}
+        csafPath="/document/notes"
+        isTouched={hasVisitedPage}
+      />
     </WizardStep>
   )
 }

--- a/src/routes/document-information/Publisher.tsx
+++ b/src/routes/document-information/Publisher.tsx
@@ -12,10 +12,12 @@ import {
   publisherCategories,
 } from './types/tDocumentPublisher'
 import { useTemplate } from '@/utils/template'
+import usePageVisit from '@/utils/usePageVisit'
 
 export default function Publisher() {
   const [localState, setLocalState] = useState(getDefaultDocumentPublisher())
   const { isFieldReadonly } = useTemplate()
+  const hasVisitedPage = usePageVisit()
 
   useDocumentStoreUpdater<TDocumentInformation>({
     localState: [localState, () => ({ publisher: localState })],
@@ -35,6 +37,7 @@ export default function Publisher() {
       <Input
         label="Name of publisher"
         csafPath="/document/publisher/name"
+        isTouched={hasVisitedPage}
         value={localState.name}
         onValueChange={(v) => setLocalState({ ...localState, name: v })}
         isDisabled={isFieldReadonly('document-information.publisher.name')}
@@ -43,6 +46,7 @@ export default function Publisher() {
         <Select
           label="Category of Publisher"
           csafPath="/document/publisher/category"
+          isTouched={hasVisitedPage}
           selectedKeys={[localState.category]}
           onSelectionChange={(selected) =>
             setLocalState({
@@ -61,6 +65,7 @@ export default function Publisher() {
         <Input
           label="Namespace of Publisher"
           csafPath="/document/publisher/namespace"
+          isTouched={hasVisitedPage}
           placeholder="e.g., https://publisher.example.org/"
           value={localState.namespace}
           onValueChange={(v) => setLocalState({ ...localState, namespace: v })}
@@ -72,6 +77,7 @@ export default function Publisher() {
       <Textarea
         label="Contact Details"
         csafPath="/document/publisher/contact_details"
+        isTouched={hasVisitedPage}
         value={localState.contactDetails}
         onValueChange={(v) =>
           setLocalState({ ...localState, contactDetails: v })
@@ -83,6 +89,7 @@ export default function Publisher() {
       <Textarea
         label="Issuing Authority"
         csafPath="/document/publisher/issuing_authority"
+        isTouched={hasVisitedPage}
         value={localState.issuingAuthority}
         onValueChange={(v) =>
           setLocalState({ ...localState, issuingAuthority: v })

--- a/src/routes/document-information/Publisher.tsx
+++ b/src/routes/document-information/Publisher.tsx
@@ -34,6 +34,7 @@ export default function Publisher() {
     >
       <Input
         label="Name of publisher"
+        csafPath="/document/publisher/name"
         value={localState.name}
         onValueChange={(v) => setLocalState({ ...localState, name: v })}
         isDisabled={isFieldReadonly('document-information.publisher.name')}
@@ -41,6 +42,7 @@ export default function Publisher() {
       <HSplit>
         <Select
           label="Category of Publisher"
+          csafPath="/document/publisher/category"
           selectedKeys={[localState.category]}
           onSelectionChange={(selected) =>
             setLocalState({
@@ -58,6 +60,7 @@ export default function Publisher() {
         </Select>
         <Input
           label="Namespace of Publisher"
+          csafPath="/document/publisher/namespace"
           placeholder="e.g., https://publisher.example.org/"
           value={localState.namespace}
           onValueChange={(v) => setLocalState({ ...localState, namespace: v })}
@@ -68,6 +71,7 @@ export default function Publisher() {
       </HSplit>
       <Textarea
         label="Contact Details"
+        csafPath="/document/publisher/contact_details"
         value={localState.contactDetails}
         onValueChange={(v) =>
           setLocalState({ ...localState, contactDetails: v })
@@ -78,6 +82,7 @@ export default function Publisher() {
       />
       <Textarea
         label="Issuing Authority"
+        csafPath="/document/publisher/issuing_authority"
         value={localState.issuingAuthority}
         onValueChange={(v) =>
           setLocalState({ ...localState, issuingAuthority: v })

--- a/src/routes/document-information/Publisher.tsx
+++ b/src/routes/document-information/Publisher.tsx
@@ -39,7 +39,7 @@ export default function Publisher() {
         onValueChange={(v) => setLocalState({ ...localState, name: v })}
         isDisabled={isFieldReadonly('document-information.publisher.name')}
       />
-      <HSplit>
+      <HSplit className="items-start">
         <Select
           label="Category of Publisher"
           csafPath="/document/publisher/category"

--- a/src/routes/document-information/References.tsx
+++ b/src/routes/document-information/References.tsx
@@ -10,11 +10,14 @@ import {
   getDefaultDocumentReference,
 } from './types/tDocumentReference'
 import { checkReadOnly } from '@/utils/template'
+import usePageVisit from '@/utils/usePageVisit'
 
 export default function References() {
   const referencesListState = useListState<TDocumentReference>({
     generator: getDefaultDocumentReference,
   })
+
+  usePageVisit()
 
   useDocumentStoreUpdater<TDocumentInformation>({
     localState: [

--- a/src/routes/products/Products.tsx
+++ b/src/routes/products/Products.tsx
@@ -3,8 +3,11 @@ import WizardStep from '@/components/WizardStep'
 import { faSearch } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import VendorList from './VendorList'
+import usePageVisit from '@/utils/usePageVisit'
 
 export default function Products() {
+  usePageVisit()
+
   return (
     <WizardStep
       title="Product Management"

--- a/src/routes/shared/NotesList.tsx
+++ b/src/routes/shared/NotesList.tsx
@@ -39,9 +39,9 @@ export function NotesList({
   csafPath,
   isTouched = false,
 }: {
-  notesListState: ListState<TNote>,
-  csafPath: string,
-  isTouched?: boolean,
+  notesListState: ListState<TNote>
+  csafPath: string
+  isTouched?: boolean
 }) {
   return (
     <ComponentList

--- a/src/routes/shared/NotesList.tsx
+++ b/src/routes/shared/NotesList.tsx
@@ -37,16 +37,23 @@ export const NoteGenerator = (): TNote => ({
 export function NotesList({
   notesListState,
   csafPath,
+  isTouched = false,
 }: {
   notesListState: ListState<TNote>,
   csafPath: string,
+  isTouched?: boolean,
 }) {
   return (
     <ComponentList
       listState={notesListState}
       title="title"
       content={(note, index) => (
-        <NoteForm note={note} csafPath={`${csafPath}/${index}`} onChange={notesListState.updateDataEntry} />
+        <NoteForm
+          note={note}
+          csafPath={`${csafPath}/${index}`}
+          isTouched={isTouched}
+          onChange={notesListState.updateDataEntry}
+        />
       )}
       startContent={(note) => <CategoryChip note={note} />}
     />
@@ -65,10 +72,12 @@ function NoteForm({
   note,
   csafPath,
   onChange,
+  isTouched = false,
 }: {
   note: TNote
   csafPath: string
   onChange: (note: TNote) => void
+  isTouched?: boolean
 }) {
   return (
     <VSplit className="pt-4">
@@ -76,6 +85,7 @@ function NoteForm({
         <Select
           label="Note category"
           csafPath={`${csafPath}/category`}
+          isTouched={isTouched}
           selectedKeys={[note.category]}
           onSelectionChange={(selected) => {
             onChange({
@@ -91,6 +101,7 @@ function NoteForm({
         </Select>
         <Input
           label="Title"
+          isTouched={isTouched}
           csafPath={`${csafPath}/title`}
           value={note.title}
           onValueChange={(newValue) => onChange({ ...note, title: newValue })}
@@ -100,6 +111,7 @@ function NoteForm({
       </HSplit>
       <Textarea
         label="Note Content"
+        isTouched={isTouched}
         csafPath={`${csafPath}/text`}
         value={note.content}
         onValueChange={(newValue) => onChange({ ...note, content: newValue })}

--- a/src/routes/shared/NotesList.tsx
+++ b/src/routes/shared/NotesList.tsx
@@ -36,15 +36,17 @@ export const NoteGenerator = (): TNote => ({
 
 export function NotesList({
   notesListState,
+  csafPath,
 }: {
-  notesListState: ListState<TNote>
+  notesListState: ListState<TNote>,
+  csafPath: string,
 }) {
   return (
     <ComponentList
       listState={notesListState}
       title="title"
-      content={(note) => (
-        <NoteForm note={note} onChange={notesListState.updateDataEntry} />
+      content={(note, index) => (
+        <NoteForm note={note} csafPath={`${csafPath}/${index}`} onChange={notesListState.updateDataEntry} />
       )}
       startContent={(note) => <CategoryChip note={note} />}
     />
@@ -61,16 +63,19 @@ function CategoryChip({ note }: { note: TNote }) {
 
 function NoteForm({
   note,
+  csafPath,
   onChange,
 }: {
   note: TNote
+  csafPath: string
   onChange: (note: TNote) => void
 }) {
   return (
     <VSplit className="pt-4">
-      <HSplit>
+      <HSplit className="items-start">
         <Select
           label="Note category"
+          csafPath={`${csafPath}/category`}
           selectedKeys={[note.category]}
           onSelectionChange={(selected) => {
             onChange({
@@ -86,6 +91,7 @@ function NoteForm({
         </Select>
         <Input
           label="Title"
+          csafPath={`${csafPath}/title`}
           value={note.title}
           onValueChange={(newValue) => onChange({ ...note, title: newValue })}
           autoFocus={true}
@@ -94,6 +100,7 @@ function NoteForm({
       </HSplit>
       <Textarea
         label="Note Content"
+        csafPath={`${csafPath}/text`}
         value={note.content}
         onValueChange={(newValue) => onChange({ ...note, content: newValue })}
         isDisabled={checkReadOnly(note, 'content')}

--- a/src/routes/vulnerabilities/General.tsx
+++ b/src/routes/vulnerabilities/General.tsx
@@ -6,9 +6,11 @@ import { checkReadOnly } from '@/utils/template'
 
 export default function General({
   vulnerability,
+  vulnerabilityIndex,
   onChange,
 }: {
-  vulnerability: TVulnerability
+  vulnerability: TVulnerability,
+  vulnerabilityIndex: number
   onChange: (vulnerability: TVulnerability) => void
 }) {
   return (
@@ -16,6 +18,7 @@ export default function General({
       <HSplit>
         <Input
           label="CVE ID"
+          csafPath={`/vulnerabilities/${vulnerabilityIndex}/cve`}
           value={vulnerability.cve}
           onValueChange={(newValue) =>
             onChange({ ...vulnerability, cve: newValue })
@@ -25,6 +28,7 @@ export default function General({
         />
         <Input
           label="CWE"
+          csafPath={`/vulnerabilities/${vulnerabilityIndex}/cwe/name`}
           value={vulnerability.cwe}
           onValueChange={(newValue) =>
             onChange({ ...vulnerability, cwe: newValue })
@@ -34,6 +38,7 @@ export default function General({
       </HSplit>
       <Input
         label="Title"
+        csafPath={`/vulnerabilities/${vulnerabilityIndex}/title`}
         value={vulnerability.title}
         onValueChange={(newValue) =>
           onChange({ ...vulnerability, title: newValue })

--- a/src/routes/vulnerabilities/General.tsx
+++ b/src/routes/vulnerabilities/General.tsx
@@ -8,10 +8,12 @@ export default function General({
   vulnerability,
   vulnerabilityIndex,
   onChange,
+  isTouched = false,
 }: {
   vulnerability: TVulnerability,
-  vulnerabilityIndex: number
+  vulnerabilityIndex: number,
   onChange: (vulnerability: TVulnerability) => void
+  isTouched?: boolean,
 }) {
   return (
     <VSplit>
@@ -19,6 +21,7 @@ export default function General({
         <Input
           label="CVE ID"
           csafPath={`/vulnerabilities/${vulnerabilityIndex}/cve`}
+          isTouched={isTouched}
           value={vulnerability.cve}
           onValueChange={(newValue) =>
             onChange({ ...vulnerability, cve: newValue })
@@ -29,6 +32,7 @@ export default function General({
         <Input
           label="CWE"
           csafPath={`/vulnerabilities/${vulnerabilityIndex}/cwe/name`}
+          isTouched={isTouched}
           value={vulnerability.cwe}
           onValueChange={(newValue) =>
             onChange({ ...vulnerability, cwe: newValue })
@@ -39,6 +43,7 @@ export default function General({
       <Input
         label="Title"
         csafPath={`/vulnerabilities/${vulnerabilityIndex}/title`}
+        isTouched={isTouched}
         value={vulnerability.title}
         onValueChange={(newValue) =>
           onChange({ ...vulnerability, title: newValue })

--- a/src/routes/vulnerabilities/General.tsx
+++ b/src/routes/vulnerabilities/General.tsx
@@ -10,10 +10,10 @@ export default function General({
   onChange,
   isTouched = false,
 }: {
-  vulnerability: TVulnerability,
-  vulnerabilityIndex: number,
+  vulnerability: TVulnerability
+  vulnerabilityIndex: number
   onChange: (vulnerability: TVulnerability) => void
-  isTouched?: boolean,
+  isTouched?: boolean
 }) {
   return (
     <VSplit>

--- a/src/routes/vulnerabilities/Notes.tsx
+++ b/src/routes/vulnerabilities/Notes.tsx
@@ -2,12 +2,16 @@ import { useListState } from '@/utils/useListState'
 import { NoteGenerator, NotesList, TNote } from '../shared/NotesList'
 import { useEffect } from 'react'
 import { TVulnerability } from './types/tVulnerability'
+import { Alert } from '@heroui/react'
+import { useListValidation } from '@/utils/useListValidation'
 
 export default function Notes({
   vulnerability,
+  vulnerabilityIndex,
   onChange,
 }: {
-  vulnerability: TVulnerability
+  vulnerability: TVulnerability,
+  vulnerabilityIndex: number,
   onChange: (vulnerability: TVulnerability) => void
 }) {
   const notesListState = useListState<TNote>({
@@ -15,11 +19,26 @@ export default function Notes({
     generator: NoteGenerator,
   })
 
+  const listValidation = useListValidation(`/vulnerabilities/${vulnerabilityIndex}/notes`, notesListState.data)
+
   useEffect(
     () => onChange({ ...vulnerability, notes: notesListState.data }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [notesListState.data],
   )
 
-  return <NotesList notesListState={notesListState} />
+  return (
+    <>
+      {listValidation.isTouched && listValidation.hasErrors && (
+        <Alert color="danger">
+          {listValidation.errorMessages.map((m) => (
+            <p key={m.path}>
+              {m.message}
+            </p>
+          ))}
+        </Alert>
+      )}
+      <NotesList notesListState={notesListState} csafPath={`/vulnerabilities/${vulnerabilityIndex}/notes`} />
+    </>
+  )
 }

--- a/src/routes/vulnerabilities/Notes.tsx
+++ b/src/routes/vulnerabilities/Notes.tsx
@@ -9,16 +9,18 @@ export default function Notes({
   vulnerability,
   vulnerabilityIndex,
   onChange,
+  isTouched = false,
 }: {
   vulnerability: TVulnerability,
   vulnerabilityIndex: number,
-  onChange: (vulnerability: TVulnerability) => void
+  onChange: (vulnerability: TVulnerability) => void,
+  isTouched?: boolean,
 }) {
   const notesListState = useListState<TNote>({
     initialData: vulnerability.notes,
     generator: NoteGenerator,
   })
-
+  
   const listValidation = useListValidation(`/vulnerabilities/${vulnerabilityIndex}/notes`, notesListState.data)
 
   useEffect(
@@ -29,7 +31,7 @@ export default function Notes({
 
   return (
     <>
-      {listValidation.isTouched && listValidation.hasErrors && (
+      {(isTouched || listValidation.isTouched) && listValidation.hasErrors && (
         <Alert color="danger">
           {listValidation.errorMessages.map((m) => (
             <p key={m.path}>
@@ -38,7 +40,11 @@ export default function Notes({
           ))}
         </Alert>
       )}
-      <NotesList notesListState={notesListState} csafPath={`/vulnerabilities/${vulnerabilityIndex}/notes`} />
+      <NotesList
+        isTouched={isTouched}
+        notesListState={notesListState}
+        csafPath={`/vulnerabilities/${vulnerabilityIndex}/notes`}
+      />
     </>
   )
 }

--- a/src/routes/vulnerabilities/Notes.tsx
+++ b/src/routes/vulnerabilities/Notes.tsx
@@ -11,17 +11,20 @@ export default function Notes({
   onChange,
   isTouched = false,
 }: {
-  vulnerability: TVulnerability,
-  vulnerabilityIndex: number,
-  onChange: (vulnerability: TVulnerability) => void,
-  isTouched?: boolean,
+  vulnerability: TVulnerability
+  vulnerabilityIndex: number
+  onChange: (vulnerability: TVulnerability) => void
+  isTouched?: boolean
 }) {
   const notesListState = useListState<TNote>({
     initialData: vulnerability.notes,
     generator: NoteGenerator,
   })
-  
-  const listValidation = useListValidation(`/vulnerabilities/${vulnerabilityIndex}/notes`, notesListState.data)
+
+  const listValidation = useListValidation(
+    `/vulnerabilities/${vulnerabilityIndex}/notes`,
+    notesListState.data,
+  )
 
   useEffect(
     () => onChange({ ...vulnerability, notes: notesListState.data }),
@@ -34,9 +37,7 @@ export default function Notes({
       {(isTouched || listValidation.isTouched) && listValidation.hasErrors && (
         <Alert color="danger">
           {listValidation.errorMessages.map((m) => (
-            <p key={m.path}>
-              {m.message}
-            </p>
+            <p key={m.path}>{m.message}</p>
           ))}
         </Alert>
       )}

--- a/src/routes/vulnerabilities/Products.tsx
+++ b/src/routes/vulnerabilities/Products.tsx
@@ -10,10 +10,9 @@ import {
 
 export default function Products({
   vulnerability,
-  vulnerabilityIndex,
   onChange,
 }: {
-  vulnerability: TVulnerability,
+  vulnerability: TVulnerability
   vulnerabilityIndex: number
   onChange: (vulnerability: TVulnerability) => void
 }) {

--- a/src/routes/vulnerabilities/Products.tsx
+++ b/src/routes/vulnerabilities/Products.tsx
@@ -10,9 +10,11 @@ import {
 
 export default function Products({
   vulnerability,
+  vulnerabilityIndex,
   onChange,
 }: {
-  vulnerability: TVulnerability
+  vulnerability: TVulnerability,
+  vulnerabilityIndex: number
   onChange: (vulnerability: TVulnerability) => void
 }) {
   const productsListState = useListState<TVulnerabilityProduct>({

--- a/src/routes/vulnerabilities/Vulnerabilities.tsx
+++ b/src/routes/vulnerabilities/Vulnerabilities.tsx
@@ -14,11 +14,14 @@ import Products from './Products'
 import { TVulnerability, getDefaultVulnerability } from './types/tVulnerability'
 import { Alert } from '@heroui/react'
 import { useListValidation } from '@/utils/useListValidation'
+import usePageVisit from '@/utils/usePageVisit'
 
 export default function Vulnerabilities() {
   const vulnerabilitiesListState = useListState<TVulnerability>({
     generator: getDefaultVulnerability,
   })
+
+  const hasVisitedPage = usePageVisit()
 
   useDocumentStoreUpdater({
     localState: vulnerabilitiesListState.data,
@@ -33,7 +36,7 @@ export default function Vulnerabilities() {
 
   return (
     <WizardStep title="Vulnerabilities" progress={3} onBack={'/products'}>
-      {listValidation.isTouched && listValidation.hasErrors && (
+      {(hasVisitedPage || listValidation.isTouched) && listValidation.hasErrors && (
         <Alert color="danger">
           {listValidation.errorMessages.map((m) => (
             <p key={m.path}>
@@ -59,6 +62,7 @@ export default function Vulnerabilities() {
           <VulnerabilityForm
             vulnerability={vulnerability}
             vulnerabilityIndex={index}
+            isTouched={hasVisitedPage}
             onChange={vulnerabilitiesListState.updateDataEntry}
           />
         )}
@@ -84,14 +88,17 @@ function VulnerabilityForm({
   vulnerability,
   vulnerabilityIndex,
   onChange,
+  isTouched = false,
 }: {
   vulnerability: TVulnerability
-  vulnerabilityIndex: number
+  vulnerabilityIndex: number,
+  isTouched?: boolean,
   onChange: (vulnerability: TVulnerability) => void
 }) {
   const tabProps = {
     vulnerability,
     vulnerabilityIndex,
+    isTouched,
     onChange,
   }
 

--- a/src/routes/vulnerabilities/Vulnerabilities.tsx
+++ b/src/routes/vulnerabilities/Vulnerabilities.tsx
@@ -12,6 +12,8 @@ import General from './General'
 import Notes from './Notes'
 import Products from './Products'
 import { TVulnerability, getDefaultVulnerability } from './types/tVulnerability'
+import { Alert } from '@heroui/react'
+import { useListValidation } from '@/utils/useListValidation'
 
 export default function Vulnerabilities() {
   const vulnerabilitiesListState = useListState<TVulnerability>({
@@ -27,8 +29,20 @@ export default function Vulnerabilities() {
     },
   })
 
+  const listValidation = useListValidation('/vulnerabilities', vulnerabilitiesListState.data)
+
   return (
     <WizardStep title="Vulnerabilities" progress={3} onBack={'/products'}>
+      {listValidation.isTouched && listValidation.hasErrors && (
+        <Alert color="danger">
+          {listValidation.errorMessages.map((m) => (
+            <p key={m.path}>
+              {m.message}
+            </p>
+          ))}
+        </Alert>
+      )}
+      {/* show search input */}
       <Input
         placeholder="Search vulnerabilities"
         startContent={
@@ -41,9 +55,10 @@ export default function Vulnerabilities() {
       <ComponentList
         listState={vulnerabilitiesListState}
         title="title"
-        content={(vulnerability) => (
+        content={(vulnerability, index) => (
           <VulnerabilityForm
             vulnerability={vulnerability}
+            vulnerabilityIndex={index}
             onChange={vulnerabilitiesListState.updateDataEntry}
           />
         )}
@@ -67,22 +82,30 @@ function CVEChip({ vulnerability }: { vulnerability: TVulnerability }) {
 
 function VulnerabilityForm({
   vulnerability,
+  vulnerabilityIndex,
   onChange,
 }: {
   vulnerability: TVulnerability
+  vulnerabilityIndex: number
   onChange: (vulnerability: TVulnerability) => void
 }) {
+  const tabProps = {
+    vulnerability,
+    vulnerabilityIndex,
+    onChange,
+  }
+
   return (
     <VSplit>
       <Tabs color="primary" radius="lg" className="gap-4 bg-transparent">
         <Tab title="General">
-          <General vulnerability={vulnerability} onChange={onChange} />
+          <General {...tabProps} />
         </Tab>
         <Tab title="Notes">
-          <Notes vulnerability={vulnerability} onChange={onChange} />
+          <Notes {...tabProps} />
         </Tab>
         <Tab title="Products">
-          <Products vulnerability={vulnerability} onChange={onChange} />
+          <Products {...tabProps} />
         </Tab>
       </Tabs>
     </VSplit>

--- a/src/routes/vulnerabilities/Vulnerabilities.tsx
+++ b/src/routes/vulnerabilities/Vulnerabilities.tsx
@@ -32,19 +32,21 @@ export default function Vulnerabilities() {
     },
   })
 
-  const listValidation = useListValidation('/vulnerabilities', vulnerabilitiesListState.data)
+  const listValidation = useListValidation(
+    '/vulnerabilities',
+    vulnerabilitiesListState.data,
+  )
 
   return (
     <WizardStep title="Vulnerabilities" progress={3} onBack={'/products'}>
-      {(hasVisitedPage || listValidation.isTouched) && listValidation.hasErrors && (
-        <Alert color="danger">
-          {listValidation.errorMessages.map((m) => (
-            <p key={m.path}>
-              {m.message}
-            </p>
-          ))}
-        </Alert>
-      )}
+      {(hasVisitedPage || listValidation.isTouched) &&
+        listValidation.hasErrors && (
+          <Alert color="danger">
+            {listValidation.errorMessages.map((m) => (
+              <p key={m.path}>{m.message}</p>
+            ))}
+          </Alert>
+        )}
       {/* show search input */}
       <Input
         placeholder="Search vulnerabilities"
@@ -91,8 +93,8 @@ function VulnerabilityForm({
   isTouched = false,
 }: {
   vulnerability: TVulnerability
-  vulnerabilityIndex: number,
-  isTouched?: boolean,
+  vulnerabilityIndex: number
+  isTouched?: boolean
   onChange: (vulnerability: TVulnerability) => void
 }) {
   const tabProps = {

--- a/src/types/csaf-validator-lib.d.ts
+++ b/src/types/csaf-validator-lib.d.ts
@@ -1,26 +1,26 @@
 declare module '@secvisogram/csaf-validator-lib/validate.js' {
-    interface ValidationMessage {
-        message: string
-        instancePath: string
-    }
+  interface ValidationMessage {
+    message: string
+    instancePath: string
+  }
 
-    interface TestResult {
-        isValid: boolean
-        warnings: ValidationMessage[]
-        errors: ValidationMessage[]
-        infos: ValidationMessage[]
-        name: string
-    }
+  interface TestResult {
+    isValid: boolean
+    warnings: ValidationMessage[]
+    errors: ValidationMessage[]
+    infos: ValidationMessage[]
+    name: string
+  }
 
-    interface Result {
-        isValid: boolean
-        tests: TestResult[]
-    }
+  interface Result {
+    isValid: boolean
+    tests: TestResult[]
+  }
 
-    export default function validate(
-        tests: any,
-        doc: any
-    ): Promise<Result>
+  export default function validate(
+    tests: unknown,
+    doc: unknown,
+  ): Promise<Result>
 }
 
 declare module '@secvisogram/csaf-validator-lib/basic.js'

--- a/src/types/csaf-validator-lib.d.ts
+++ b/src/types/csaf-validator-lib.d.ts
@@ -1,0 +1,26 @@
+declare module '@secvisogram/csaf-validator-lib/validate.js' {
+    interface ValidationMessage {
+        message: string
+        instancePath: string
+    }
+
+    interface TestResult {
+        isValid: boolean
+        warnings: ValidationMessage[]
+        errors: ValidationMessage[]
+        infos: ValidationMessage[]
+        name: string
+    }
+
+    interface Result {
+        isValid: boolean
+        tests: TestResult[]
+    }
+
+    export default function validate(
+        tests: any,
+        doc: any
+    ): Promise<Result>
+}
+
+declare module '@secvisogram/csaf-validator-lib/basic.js'

--- a/src/utils/csafExport/csafExport.ts
+++ b/src/utils/csafExport/csafExport.ts
@@ -1,82 +1,88 @@
 import { download } from '../download'
-import useDocumentStore from '../useDocumentStore'
+import useDocumentStore, { TDocumentStore } from '../useDocumentStore'
 import { getFilename } from './helpers'
 import { parseNote } from './parseNote'
 import { parseProductTreeBranches } from './parseProductTreeBranches'
 import { PidGenerator } from './pidGenerator'
 
+export function createCSAFDocument(documentStore: TDocumentStore) {
+  const pidGenerator = new PidGenerator()
+  const currentDate = new Date().toISOString()
+
+  const csafDocument = {
+    document: {
+      category: 'csaf_security_advisory',
+      csaf_version: '2.0',
+      tracking: {
+        generator: {
+          date: currentDate,
+          engine: {
+            version: '0.0.1',
+            name: 'Sec-O-Simple',
+          },
+        },
+        current_release_date: currentDate,
+        initial_release_date: currentDate,
+        revision_history: [
+          {
+            date: currentDate,
+            number: '1',
+            summary: 'Initial revision',
+          },
+        ],
+        status: 'final',
+        version: '1',
+        id: documentStore.documentInformation.id,
+      },
+      lang: documentStore.documentInformation.language,
+      title: documentStore.documentInformation.title,
+      publisher: {
+        category: documentStore.documentInformation.publisher.category,
+        contact_details:
+          documentStore.documentInformation.publisher.contactDetails,
+        issuing_authority:
+          documentStore.documentInformation.publisher.issuingAuthority,
+        name: documentStore.documentInformation.publisher.name,
+        namespace: documentStore.documentInformation.publisher.namespace,
+      },
+      notes: documentStore.documentInformation.notes.map(parseNote),
+    },
+    product_tree: {
+      branches: parseProductTreeBranches(
+        Object.values(documentStore.products),
+        pidGenerator,
+      ),
+    },
+    vulnerabilities: Object.values(documentStore.vulnerabilities).map(
+      (vulnerability) => ({
+        cve: vulnerability.cve,
+        title: vulnerability.title,
+        cwe: {
+          // TODO: add further CWE support
+          id: 'not supported by sec-o-simple yet',
+          name: vulnerability.cwe,
+        },
+        notes: vulnerability.notes.map(parseNote),
+        product_status: {
+          known_affected: vulnerability.products.map((p) =>
+            pidGenerator.getPid(p.firstAffectedVersionId),
+          ),
+          fixed: vulnerability.products.map((p) =>
+            pidGenerator.getPid(p.firstFixedVersionId),
+          ),
+        },
+      }),
+    ),
+  }
+
+  return csafDocument
+}
+
 export function useCSAFExport() {
   const documentStore = useDocumentStore()
 
   const exportCSAFDocument = () => {
-    const pidGenerator = new PidGenerator()
-    const currentDate = new Date().toISOString()
-
-    const csafDocument = {
-      document: {
-        category: 'csaf_security_advisory',
-        csaf_version: '2.0',
-        tracking: {
-          generator: {
-            date: currentDate,
-            engine: {
-              version: '0.0.1',
-              name: 'Sec-O-Simple',
-            },
-          },
-          current_release_date: currentDate,
-          initial_release_date: currentDate,
-          revision_history: [
-            {
-              date: currentDate,
-              number: '1',
-              summary: 'Initial revision',
-            },
-          ],
-          status: 'final',
-          version: '1',
-          id: documentStore.documentInformation.id,
-        },
-        lang: documentStore.documentInformation.language,
-        title: documentStore.documentInformation.title,
-        publisher: {
-          category: documentStore.documentInformation.publisher.category,
-          contact_details:
-            documentStore.documentInformation.publisher.contactDetails,
-          issuing_authority:
-            documentStore.documentInformation.publisher.issuingAuthority,
-          name: documentStore.documentInformation.publisher.name,
-          namespace: documentStore.documentInformation.publisher.namespace,
-        },
-        notes: documentStore.documentInformation.notes.map(parseNote),
-      },
-      product_tree: {
-        branches: parseProductTreeBranches(
-          Object.values(documentStore.products),
-          pidGenerator,
-        ),
-      },
-      vulnerabilities: Object.values(documentStore.vulnerabilities).map(
-        (vulnerability) => ({
-          cve: vulnerability.cve,
-          title: vulnerability.title,
-          cwe: {
-            // TODO: add further CWE support
-            id: 'not supported by sec-o-simple yet',
-            name: vulnerability.cwe,
-          },
-          notes: vulnerability.notes.map(parseNote),
-          product_status: {
-            known_affected: vulnerability.products.map((p) =>
-              pidGenerator.getPid(p.firstAffectedVersionId),
-            ),
-            fixed: vulnerability.products.map((p) =>
-              pidGenerator.getPid(p.firstFixedVersionId),
-            ),
-          },
-        }),
-      ),
-    }
+    const csafDocument = createCSAFDocument(documentStore)
 
     download(
       `${getFilename(documentStore.documentInformation.id)}.json`,

--- a/src/utils/documentValidator.ts
+++ b/src/utils/documentValidator.ts
@@ -1,0 +1,63 @@
+import { TDocumentStore } from '@/utils/useDocumentStore'
+import { createCSAFDocument } from './csafExport/csafExport'
+
+import validate from '@secvisogram/csaf-validator-lib/validate.js'
+import * as basic from '@secvisogram/csaf-validator-lib/basic.js'
+import { ValidationMessage } from './useValidationStore'
+
+const tests: unknown[] = [
+  ...Object.values(basic),
+]
+
+export interface ValidationResult {
+  isValid: boolean
+  messages: ValidationMessage[]
+}
+
+export async function validateDocument(documentStore: TDocumentStore): Promise<ValidationResult> {
+  try {
+    const csafDocument = createCSAFDocument(documentStore)
+    const result = await validate(tests, csafDocument)
+
+    // Collect all messages with their severity
+    const messages: ValidationMessage[] = []
+    
+    result.tests.forEach(test => {
+      test.errors.forEach(error => {
+        messages.push({
+          path: error.instancePath,
+          message: error.message,
+          severity: 'error'
+        })
+      })
+      
+      test.warnings.forEach(warning => {
+        messages.push({
+          path: warning.instancePath,
+          message: warning.message,
+          severity: 'warning'
+        })
+      })
+      
+      test.infos.forEach(info => {
+        messages.push({
+          path: info.instancePath,
+          message: info.message,
+          severity: 'info'
+        })
+      })
+    })
+
+    console.log(messages)
+
+    return {
+      isValid: result.isValid,
+      messages: messages,
+    }
+  } catch (error) {
+    return {
+      isValid: false,
+      messages: [],
+    }
+  }
+}

--- a/src/utils/documentValidator.ts
+++ b/src/utils/documentValidator.ts
@@ -20,7 +20,7 @@ export async function validateDocument(
     const result = await validate(tests, csafDocument)
 
     // Collect all messages with their severity
-    const messages: ValidationMessage[] = []
+    let messages: ValidationMessage[] = []
 
     result.tests.forEach((test) => {
       test.errors.forEach((error) => {
@@ -48,9 +48,19 @@ export async function validateDocument(
       })
     })
 
+    // Filter out messages for now that we have not implemented
+    messages = messages.filter(m => (
+      !m.path.startsWith('/product_tree/') &&
+      !m.path.endsWith('/cwe/id') &&
+      !m.path.endsWith('/product_status/fixed') &&
+      !m.path.endsWith('/product_status/known_affected')
+    ))
+
     return {
-      isValid: result.isValid,
-      messages: messages,
+      // We want to use result.isValid when we implemented all fields
+      // but for now we use the messages length to determine if the document is valid
+      isValid: messages.filter(m => m.severity === 'error').length === 0,
+      messages,
     }
   } catch (error) {
     return {

--- a/src/utils/documentValidator.ts
+++ b/src/utils/documentValidator.ts
@@ -49,17 +49,18 @@ export async function validateDocument(
     })
 
     // Filter out messages for now that we have not implemented
-    messages = messages.filter(m => (
-      !m.path.startsWith('/product_tree/') &&
-      !m.path.endsWith('/cwe/id') &&
-      !m.path.endsWith('/product_status/fixed') &&
-      !m.path.endsWith('/product_status/known_affected')
-    ))
+    messages = messages.filter(
+      (m) =>
+        !m.path.startsWith('/product_tree/') &&
+        !m.path.endsWith('/cwe/id') &&
+        !m.path.endsWith('/product_status/fixed') &&
+        !m.path.endsWith('/product_status/known_affected'),
+    )
 
     return {
       // We want to use result.isValid when we implemented all fields
       // but for now we use the messages length to determine if the document is valid
-      isValid: messages.filter(m => m.severity === 'error').length === 0,
+      isValid: messages.filter((m) => m.severity === 'error').length === 0,
       messages,
     }
   } catch (error) {

--- a/src/utils/documentValidator.ts
+++ b/src/utils/documentValidator.ts
@@ -5,50 +5,48 @@ import validate from '@secvisogram/csaf-validator-lib/validate.js'
 import * as basic from '@secvisogram/csaf-validator-lib/basic.js'
 import { ValidationMessage } from './useValidationStore'
 
-const tests: unknown[] = [
-  ...Object.values(basic),
-]
+const tests: unknown[] = [...Object.values(basic)]
 
 export interface ValidationResult {
   isValid: boolean
   messages: ValidationMessage[]
 }
 
-export async function validateDocument(documentStore: TDocumentStore): Promise<ValidationResult> {
+export async function validateDocument(
+  documentStore: TDocumentStore,
+): Promise<ValidationResult> {
   try {
     const csafDocument = createCSAFDocument(documentStore)
     const result = await validate(tests, csafDocument)
 
     // Collect all messages with their severity
     const messages: ValidationMessage[] = []
-    
-    result.tests.forEach(test => {
-      test.errors.forEach(error => {
+
+    result.tests.forEach((test) => {
+      test.errors.forEach((error) => {
         messages.push({
           path: error.instancePath,
           message: error.message,
-          severity: 'error'
+          severity: 'error',
         })
       })
-      
-      test.warnings.forEach(warning => {
+
+      test.warnings.forEach((warning) => {
         messages.push({
           path: warning.instancePath,
           message: warning.message,
-          severity: 'warning'
+          severity: 'warning',
         })
       })
-      
-      test.infos.forEach(info => {
+
+      test.infos.forEach((info) => {
         messages.push({
           path: info.instancePath,
           message: info.message,
-          severity: 'info'
+          severity: 'info',
         })
       })
     })
-
-    console.log(messages)
 
     return {
       isValid: result.isValid,

--- a/src/utils/useDebounceInput.ts
+++ b/src/utils/useDebounceInput.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from "react"
+
+type InputElement = HTMLInputElement | HTMLTextAreaElement
+type InputChangeEvent<T> = React.ChangeEvent<T>
+type InputBlurEvent<T> = React.FocusEvent<T>
+
+interface UseDebounceInputOptions<T extends InputElement> {
+    onChange?: (e: InputChangeEvent<T>) => void
+    onBlur?: (e: InputBlurEvent<T>) => void
+    value?: string
+}
+
+export function useDebounceInput<T extends InputElement>({
+    onChange,
+    onBlur,
+    value: propValue,
+}: UseDebounceInputOptions<T>) {
+    const [isDebouncing, setIsDebouncing] = useState(false)
+    const timeoutRef = useRef<NodeJS.Timeout>()
+    const [debouncedValue, setDebouncedValue] = useState<string>(propValue ?? '')
+
+    useEffect(() => {
+        if (propValue !== undefined) {
+            setDebouncedValue(propValue)
+        }
+    }, [propValue])
+
+    const triggerOnChange = (value: string) => {
+        const syntheticEvent = {
+            target: { value },
+            currentTarget: { value }
+        } as InputChangeEvent<T>
+        onChange?.(syntheticEvent)
+    }
+
+    const clearPendingTimeout = () => {
+        if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current)
+            timeoutRef.current = undefined
+        }
+    }
+
+    const handleBlur = (e: InputBlurEvent<T>) => {
+        clearPendingTimeout()
+
+        if (isDebouncing) {
+            triggerOnChange(debouncedValue)
+        }
+
+        setIsDebouncing(false)
+        onBlur?.(e)
+    }
+
+    const handleChange = (e: InputChangeEvent<T>) => {
+        const value = e.target.value
+        setDebouncedValue(value)
+        setIsDebouncing(true)
+
+        clearPendingTimeout()
+
+        timeoutRef.current = setTimeout(() => {
+            setIsDebouncing(false)
+            triggerOnChange(value)
+        }, 400)
+    }
+
+    useEffect(() => {
+        return clearPendingTimeout
+    }, [])
+
+    return {
+        value: debouncedValue,
+        isDebouncing,
+        handleBlur,
+        handleChange
+    }
+}

--- a/src/utils/useDocumentStoreUpdater.ts
+++ b/src/utils/useDocumentStoreUpdater.ts
@@ -28,8 +28,14 @@ export type useDocumentStoreUpdaterProps<T> = {
 
 export function useDocumentValidation() {
   const documentStore = useDocumentStore()
-  const setValidationState = useValidationStore(state => state.setValidationState)
-  const setIsValidating = useValidationStore(state => state.setIsValidating)
+  const setValidationState = useValidationStore(
+    (state) => state.setValidationState,
+  )
+  const setIsValidating = useValidationStore((state) => state.setIsValidating)
+
+  // JSON.stringify is used to avoid calling the validation function
+  // if the documentStore has not changed
+  const documentStoreString = JSON.stringify(documentStore)
 
   useEffect(() => {
     const validate = async () => {
@@ -42,13 +48,13 @@ export function useDocumentValidation() {
         })
       } finally {
         setIsValidating(false)
-      } 
+      }
     }
 
     validate()
-    // JSON.stringify is used to avoid calling the validation function
-    // if the documentStore has not changed
-  }, [JSON.stringify(documentStore), setValidationState, setIsValidating])
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [documentStoreString, setValidationState, setIsValidating])
 }
 
 export default function useDocumentStoreUpdater<T>({

--- a/src/utils/useDocumentStoreUpdater.ts
+++ b/src/utils/useDocumentStoreUpdater.ts
@@ -1,6 +1,8 @@
 import { useEffect } from 'react'
 import useDocumentStore, { TDocumentStore } from './useDocumentStore'
 import { useConfigStore } from './useConfigStore'
+import useValidationStore from './useValidationStore'
+import { validateDocument } from './documentValidator'
 
 type TDocumentStoreFunction<T> = {
   [K in keyof TDocumentStore]: TDocumentStore[K] extends (update: T) => void
@@ -24,6 +26,31 @@ export type useDocumentStoreUpdaterProps<T> = {
   init: (initialData: T) => void
 }
 
+export function useDocumentValidation() {
+  const documentStore = useDocumentStore()
+  const setValidationState = useValidationStore(state => state.setValidationState)
+  const setIsValidating = useValidationStore(state => state.setIsValidating)
+
+  useEffect(() => {
+    const validate = async () => {
+      try {
+        setIsValidating(true)
+        const result = await validateDocument(documentStore)
+        setValidationState({
+          isValid: result.isValid,
+          messages: result.messages,
+        })
+      } finally {
+        setIsValidating(false)
+      } 
+    }
+
+    validate()
+    // JSON.stringify is used to avoid calling the validation function
+    // if the documentStore has not changed
+  }, [JSON.stringify(documentStore), setValidationState, setIsValidating])
+}
+
 export default function useDocumentStoreUpdater<T>({
   localState,
   valueField,
@@ -35,6 +62,7 @@ export default function useDocumentStoreUpdater<T>({
   const updateDocumentStoreValue = useDocumentStore(
     (state) => state[valueUpdater],
   ) as (update: T) => void
+  useDocumentValidation()
 
   // initialize localState after config has been fetched
   useEffect(() => {

--- a/src/utils/useFieldValidation.ts
+++ b/src/utils/useFieldValidation.ts
@@ -1,0 +1,22 @@
+import useValidationStore from '@/utils/useValidationStore'
+
+export function useFieldValidation(path?: string) {
+  const validationStore = useValidationStore()
+
+  const messages = !path ? [] : validationStore.getMessagesForPath(path)
+  const errorMessages = messages.filter(m => m.severity === 'error')
+  const warningMessages = messages.filter(m => m.severity === 'warning')
+  const infoMessages = messages.filter(m => m.severity === 'info')
+
+  return {
+    messages,
+    hasErrors: errorMessages.length > 0,
+    hasWarnings: warningMessages.length > 0,
+    hasInfos: infoMessages.length > 0,
+    errorMessages,
+    warningMessages,
+    infoMessages,
+    isTouched: !path ? true : validationStore.isFieldTouched(path),
+    markFieldAsTouched: validationStore.markFieldAsTouched,
+  }
+}

--- a/src/utils/useFieldValidation.ts
+++ b/src/utils/useFieldValidation.ts
@@ -4,9 +4,9 @@ export function useFieldValidation(path?: string) {
   const validationStore = useValidationStore()
 
   const messages = !path ? [] : validationStore.getMessagesForPath(path)
-  const errorMessages = messages.filter(m => m.severity === 'error')
-  const warningMessages = messages.filter(m => m.severity === 'warning')
-  const infoMessages = messages.filter(m => m.severity === 'info')
+  const errorMessages = messages.filter((m) => m.severity === 'error')
+  const warningMessages = messages.filter((m) => m.severity === 'warning')
+  const infoMessages = messages.filter((m) => m.severity === 'info')
 
   return {
     messages,

--- a/src/utils/useListValidation.ts
+++ b/src/utils/useListValidation.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react"
+import { useFieldValidation } from "./useFieldValidation"
+import useValidationStore from "./useValidationStore"
+
+/**
+ * Custom hook to manage validation for a list of items.
+ * It marks the field as touched when the list is changed or when it is not empty.
+ */
+export function useListValidation(listPath: string, data: any[]) {
+    const listValidation = useFieldValidation(listPath)
+    const markFieldAsTouched = useValidationStore(
+        (state) => state.markFieldAsTouched,
+    )
+
+    useEffect(() => {
+        // When changing the list once or if it's not empty,
+        // mark the field as touched so we can show an error
+        if (data.length > 0) {
+            markFieldAsTouched(listPath)
+        }
+    }, [data, markFieldAsTouched, listPath])
+
+    return listValidation
+}

--- a/src/utils/useListValidation.ts
+++ b/src/utils/useListValidation.ts
@@ -1,24 +1,24 @@
-import { useEffect } from "react"
-import { useFieldValidation } from "./useFieldValidation"
-import useValidationStore from "./useValidationStore"
+import { useEffect } from 'react'
+import { useFieldValidation } from './useFieldValidation'
+import useValidationStore from './useValidationStore'
 
 /**
  * Custom hook to manage validation for a list of items.
  * It marks the field as touched when the list is changed or when it is not empty.
  */
-export function useListValidation(listPath: string, data: any[]) {
-    const listValidation = useFieldValidation(listPath)
-    const markFieldAsTouched = useValidationStore(
-        (state) => state.markFieldAsTouched,
-    )
+export function useListValidation(listPath: string, data: unknown[]) {
+  const listValidation = useFieldValidation(listPath)
+  const markFieldAsTouched = useValidationStore(
+    (state) => state.markFieldAsTouched,
+  )
 
-    useEffect(() => {
-        // When changing the list once or if it's not empty,
-        // mark the field as touched so we can show an error
-        if (data.length > 0) {
-            markFieldAsTouched(listPath)
-        }
-    }, [data, markFieldAsTouched, listPath])
+  useEffect(() => {
+    // When changing the list once or if it's not empty,
+    // mark the field as touched so we can show an error
+    if (data.length > 0) {
+      markFieldAsTouched(listPath)
+    }
+  }, [data, markFieldAsTouched, listPath])
 
-    return listValidation
+  return listValidation
 }

--- a/src/utils/usePageVisit.ts
+++ b/src/utils/usePageVisit.ts
@@ -1,14 +1,14 @@
-import { useEffect, useState } from "react"
-import useValidationStore from "./useValidationStore"
-import { useLocation } from "react-router"
+import { useEffect, useState } from 'react'
+import useValidationStore from './useValidationStore'
+import { useLocation } from 'react-router'
 
 /**
  * A hook that tracks page visits and manages page visit state.
  * It marks a page as visited after a brief delay and tracks whether the current page
  * has been previously visited.
- * 
+ *
  * @returns {boolean} Returns true if the current page has been previously visited, false otherwise
- * 
+ *
  * @example
  * function MyComponent() {
  *   const hasVisited = usePageVisit();
@@ -16,25 +16,25 @@ import { useLocation } from "react-router"
  * }
  */
 export default function usePageVisit() {
-    const visitPage = useValidationStore((state) => state.visitPage)
-    const hasVisitedPage = useValidationStore((state) => state.hasVisitedPage)
-    const [visitedPage, setHasVisitedPage] = useState(false)
-    const location = useLocation()
+  const visitPage = useValidationStore((state) => state.visitPage)
+  const hasVisitedPage = useValidationStore((state) => state.hasVisitedPage)
+  const [visitedPage, setHasVisitedPage] = useState(false)
+  const location = useLocation()
 
-    useEffect(() => {
-        // Check if page was previously visited
-        if (hasVisitedPage(location.pathname)) {
-            setHasVisitedPage(true)
-        }
+  useEffect(() => {
+    // Check if page was previously visited
+    if (hasVisitedPage(location.pathname)) {
+      setHasVisitedPage(true)
+    }
 
-        // Mark page as visited after short delay
-        const timeoutId = setTimeout(() => {
-            visitPage(location.pathname)
-        }, 500)
+    // Mark page as visited after short delay
+    const timeoutId = setTimeout(() => {
+      visitPage(location.pathname)
+    }, 500)
 
-        // Cleanup timeout if user leaves page before delay
-        return () => clearTimeout(timeoutId)
-    }, [location.pathname, visitPage, hasVisitedPage])
+    // Cleanup timeout if user leaves page before delay
+    return () => clearTimeout(timeoutId)
+  }, [location.pathname, visitPage, hasVisitedPage])
 
-    return visitedPage
+  return visitedPage
 }

--- a/src/utils/usePageVisit.ts
+++ b/src/utils/usePageVisit.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react"
+import useValidationStore from "./useValidationStore"
+import { useLocation } from "react-router"
+
+/**
+ * A hook that tracks page visits and manages page visit state.
+ * It marks a page as visited after a brief delay and tracks whether the current page
+ * has been previously visited.
+ * 
+ * @returns {boolean} Returns true if the current page has been previously visited, false otherwise
+ * 
+ * @example
+ * function MyComponent() {
+ *   const hasVisited = usePageVisit();
+ *   return hasVisited ? <div>Welcome back!</div> : <div>First time here!</div>;
+ * }
+ */
+export default function usePageVisit() {
+    const visitPage = useValidationStore((state) => state.visitPage)
+    const hasVisitedPage = useValidationStore((state) => state.hasVisitedPage)
+    const [visitedPage, setHasVisitedPage] = useState(false)
+    const location = useLocation()
+
+    useEffect(() => {
+        // Check if page was previously visited
+        if (hasVisitedPage(location.pathname)) {
+            setHasVisitedPage(true)
+        }
+
+        // Mark page as visited after short delay
+        const timeoutId = setTimeout(() => {
+            visitPage(location.pathname)
+        }, 500)
+
+        // Cleanup timeout if user leaves page before delay
+        return () => clearTimeout(timeoutId)
+    }, [location.pathname, visitPage, hasVisitedPage])
+
+    return visitedPage
+}

--- a/src/utils/usePathValidation.ts
+++ b/src/utils/usePathValidation.ts
@@ -1,31 +1,34 @@
-import useValidationStore from "./useValidationStore"
+import useValidationStore from './useValidationStore'
 
 type HasErrorFunction = (errorPaths: string[]) => boolean
-  
 
 const validationSections: Record<string, HasErrorFunction> = {
   '/document-information/general': (errorPaths) => {
-    return ['/document/title', '/document/tracking/id', '/document/lang'].some(path => errorPaths.includes(path))
+    return ['/document/title', '/document/tracking/id', '/document/lang'].some(
+      (path) => errorPaths.includes(path),
+    )
   },
   '/document-information/notes': (errorPaths) => {
-    return errorPaths.some(path => path.startsWith('/document/notes'))
+    return errorPaths.some((path) => path.startsWith('/document/notes'))
   },
   '/document-information/publisher': (errorPaths) => {
-    return errorPaths.some(path => path.startsWith('/document/publisher'))
+    return errorPaths.some((path) => path.startsWith('/document/publisher'))
   },
   '/products': (errorPaths) => {
-    return errorPaths.some(path => path.startsWith('/products'))
+    return errorPaths.some((path) => path.startsWith('/products'))
   },
   '/vulnerabilities': (errorPaths) => {
-    return errorPaths.some(path => path.startsWith('/vulnerabilities'))
-  }
+    return errorPaths.some((path) => path.startsWith('/vulnerabilities'))
+  },
 }
 
 export function usePathValidation(path: string) {
-  const messages = useValidationStore(state => state.messages)
-  const errorPaths = messages.filter(m => m.severity === 'error').map(e => e.path)
-  const hasVisitedPage = useValidationStore(state => state.hasVisitedPage)
-  
+  const messages = useValidationStore((state) => state.messages)
+  const errorPaths = messages
+    .filter((m) => m.severity === 'error')
+    .map((e) => e.path)
+  const hasVisitedPage = useValidationStore((state) => state.hasVisitedPage)
+
   if (validationSections[path]) {
     const hasErrors = validationSections[path](errorPaths)
     return {

--- a/src/utils/usePathValidation.ts
+++ b/src/utils/usePathValidation.ts
@@ -1,0 +1,41 @@
+import useValidationStore from "./useValidationStore"
+
+type HasErrorFunction = (errorPaths: string[]) => boolean
+  
+
+const validationSections: Record<string, HasErrorFunction> = {
+  '/document-information/general': (errorPaths) => {
+    return ['/document/title', '/document/tracking/id', '/document/lang'].some(path => errorPaths.includes(path))
+  },
+  '/document-information/notes': (errorPaths) => {
+    return errorPaths.some(path => path.startsWith('/document/notes'))
+  },
+  '/document-information/publisher': (errorPaths) => {
+    return errorPaths.some(path => path.startsWith('/document/publisher'))
+  },
+  '/products': (errorPaths) => {
+    return errorPaths.some(path => path.startsWith('/products'))
+  },
+  '/vulnerabilities': (errorPaths) => {
+    return errorPaths.some(path => path.startsWith('/vulnerabilities'))
+  }
+}
+
+export function usePathValidation(path: string) {
+  const messages = useValidationStore(state => state.messages)
+  const errorPaths = messages.filter(m => m.severity === 'error').map(e => e.path)
+  const hasVisitedPage = useValidationStore(state => state.hasVisitedPage)
+  
+  if (validationSections[path]) {
+    const hasErrors = validationSections[path](errorPaths)
+    return {
+      hasErrors,
+      hasVisited: hasVisitedPage(path),
+    }
+  }
+
+  return {
+    hasErrors: false,
+    hasVisited: hasVisitedPage(path),
+  }
+}

--- a/src/utils/useValidationStore.ts
+++ b/src/utils/useValidationStore.ts
@@ -44,7 +44,7 @@ const useValidationStore = create<ValidationStore>((set, get) => ({
   setIsValidating: (isValidating: boolean) => set({ isValidating }),
 
   getMessagesForPath: (path: string) => {
-    return get().messages.filter((message) => message.path.startsWith(path))
+    return get().messages.filter((message) => message.path === path)
   },
 
   isFieldTouched(path: string) {

--- a/src/utils/useValidationStore.ts
+++ b/src/utils/useValidationStore.ts
@@ -14,9 +14,9 @@ type ValidationStore = {
   isValidating: boolean
   isValid: boolean
 
-  setValidationState: (params: { 
-    messages: ValidationMessage[], 
-    isValid: boolean 
+  setValidationState: (params: {
+    messages: ValidationMessage[]
+    isValid: boolean
   }) => void
   setIsValidating: (isValidating: boolean) => void
   markFieldAsTouched: (path: string) => void
@@ -35,8 +35,8 @@ const useValidationStore = create<ValidationStore>((set, get) => ({
   isValidating: false,
   isValid: true,
 
-  setValidationState: ({ messages, isValid }) => 
-    set({ 
+  setValidationState: ({ messages, isValid }) =>
+    set({
       messages,
       isValid,
     }),
@@ -44,7 +44,7 @@ const useValidationStore = create<ValidationStore>((set, get) => ({
   setIsValidating: (isValidating: boolean) => set({ isValidating }),
 
   getMessagesForPath: (path: string) => {
-    return get().messages.filter(message => message.path.startsWith(path))
+    return get().messages.filter((message) => message.path.startsWith(path))
   },
 
   isFieldTouched(path: string) {
@@ -52,21 +52,21 @@ const useValidationStore = create<ValidationStore>((set, get) => ({
   },
 
   markFieldAsTouched: (path: string) =>
-    set(state => ({ 
-      touchedFields: new Set([...state.touchedFields, path]) 
+    set((state) => ({
+      touchedFields: new Set([...state.touchedFields, path]),
     })),
 
   get errors() {
-    return get().messages.filter(m => m.severity === 'error')
+    return get().messages.filter((m) => m.severity === 'error')
   },
 
   get warnings() {
-    return get().messages.filter(m => m.severity === 'warning')
+    return get().messages.filter((m) => m.severity === 'warning')
   },
 
   get infos() {
-    return get().messages.filter(m => m.severity === 'info')
-  }
+    return get().messages.filter((m) => m.severity === 'info')
+  },
 }))
 
 export default useValidationStore

--- a/src/utils/useValidationStore.ts
+++ b/src/utils/useValidationStore.ts
@@ -1,0 +1,72 @@
+import { create } from 'zustand'
+
+export type ValidationSeverity = 'error' | 'warning' | 'info'
+
+export type ValidationMessage = {
+  path: string
+  message: string
+  severity: ValidationSeverity
+}
+
+type ValidationStore = {
+  messages: ValidationMessage[]
+  touchedFields: Set<string>
+  isValidating: boolean
+  isValid: boolean
+
+  setValidationState: (params: { 
+    messages: ValidationMessage[], 
+    isValid: boolean 
+  }) => void
+  setIsValidating: (isValidating: boolean) => void
+  markFieldAsTouched: (path: string) => void
+  getMessagesForPath: (path: string) => ValidationMessage[]
+  isFieldTouched: (path: string) => boolean
+
+  errors: ValidationMessage[]
+  warnings: ValidationMessage[]
+  infos: ValidationMessage[]
+}
+
+const useValidationStore = create<ValidationStore>((set, get) => ({
+  messages: [],
+  touchedFields: new Set(),
+  visitedPages: new Set(),
+  isValidating: false,
+  isValid: true,
+
+  setValidationState: ({ messages, isValid }) => 
+    set({ 
+      messages,
+      isValid,
+    }),
+
+  setIsValidating: (isValidating: boolean) => set({ isValidating }),
+
+  getMessagesForPath: (path: string) => {
+    return get().messages.filter(message => message.path.startsWith(path))
+  },
+
+  isFieldTouched(path: string) {
+    return get().touchedFields.has(path)
+  },
+
+  markFieldAsTouched: (path: string) =>
+    set(state => ({ 
+      touchedFields: new Set([...state.touchedFields, path]) 
+    })),
+
+  get errors() {
+    return get().messages.filter(m => m.severity === 'error')
+  },
+
+  get warnings() {
+    return get().messages.filter(m => m.severity === 'warning')
+  },
+
+  get infos() {
+    return get().messages.filter(m => m.severity === 'info')
+  }
+}))
+
+export default useValidationStore

--- a/src/utils/useValidationStore.ts
+++ b/src/utils/useValidationStore.ts
@@ -11,6 +11,7 @@ export type ValidationMessage = {
 type ValidationStore = {
   messages: ValidationMessage[]
   touchedFields: Set<string>
+  visitedPages: Set<string>
   isValidating: boolean
   isValid: boolean
 
@@ -22,6 +23,8 @@ type ValidationStore = {
   markFieldAsTouched: (path: string) => void
   getMessagesForPath: (path: string) => ValidationMessage[]
   isFieldTouched: (path: string) => boolean
+  visitPage: (path: string) => void
+  hasVisitedPage: (path: string) => boolean
 
   errors: ValidationMessage[]
   warnings: ValidationMessage[]
@@ -49,6 +52,15 @@ const useValidationStore = create<ValidationStore>((set, get) => ({
 
   isFieldTouched(path: string) {
     return get().touchedFields.has(path)
+  },
+
+  visitPage: (path: string) =>
+    set((state) => ({
+      visitedPages: new Set([...state.visitedPages, path]),
+    })),
+
+  hasVisitedPage: (path: string) => {
+    return get().visitedPages.has(path)
   },
 
   markFieldAsTouched: (path: string) =>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,8 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": [
-    "src"
+    "src",
+    "src/types/*.d.ts"
   ],
   "references": [
     {


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
Added CSAF document validation throughout the application, including visual feedback in the navigation menu. The validation follows these principles:
- Fields are only validated after being touched or when leaving a page
- Navigation shows validation status through colored indicators (red/green/gray)
- Export is only possible when there are no errors left (for now I excluded some errors that we don't have fields for yet)

## Technical Changes
- Integrate `@secvisogram/csaf-validator-lib` for CSAF schema validation
- Add validation store to manage validation state
- Add continuous validation of document changes
- Add TypeScript definitions for CSAF validator

## Future Work
- Improve error messages: Currently very technical
- Add remaining fields or fill them out properly (like CWE ID)

## Screenshot/Video
https://github.com/user-attachments/assets/0f3ca2d0-63e2-4462-9bcf-0d47c5f36d68


