### PR TITLE
fix: references not included in csaf export

### DIFF
--- a/src/utils/csafExport/csafExport.ts
+++ b/src/utils/csafExport/csafExport.ts
@@ -46,6 +46,12 @@ export function createCSAFDocument(documentStore: TDocumentStore) {
         namespace: documentStore.documentInformation.publisher.namespace,
       },
       notes: documentStore.documentInformation.notes.map(parseNote),
+      references: documentStore.documentInformation.references.map(
+        (reference) => ({
+          summary: reference.summary,
+          url: reference.url,
+        }),
+      ),
     },
     product_tree: {
       branches: parseProductTreeBranches(


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description

References are now included in the csaf export