### PR TITLE
feat: highlight add-new-item buttons

### DIFF
--- a/src/components/forms/AddItemButton.tsx
+++ b/src/components/forms/AddItemButton.tsx
@@ -18,7 +18,7 @@ export default function AddItemButton(props: AddItemButtonProps) {
       {...buttonProps}
       variant="bordered"
       className={twMerge(
-        'border-dashed text-neutral-foreground border-gray',
+        'border-dashed text-primary border-primary',
         buttonProps.className ?? '',
       )}
     >


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description

Add-Item button in list components is now highlighted in the primary color:
![image](https://github.com/user-attachments/assets/bc7dc9f8-06cc-4afa-8b75-36990e6fc559)