### PR TITLE
feat: add CWE integration

### DIFF
--- a/src/components/forms/Autocomplete.tsx
+++ b/src/components/forms/Autocomplete.tsx
@@ -1,0 +1,50 @@
+import { useDebounceInput } from '@/utils/useDebounceInput'
+import { useFieldValidation } from '@/utils/useFieldValidation'
+import {
+  Autocomplete as HeroUIAutocomplete,
+  AutocompleteProps,
+} from '@heroui/react'
+
+export function Autocomplete(
+  props: AutocompleteProps & { csafPath?: string; isTouched?: boolean },
+) {
+  const {
+    placeholder,
+    labelPlacement,
+    variant,
+    csafPath,
+    isTouched,
+    onBlur,
+    onChange,
+    onValueChange,
+    value: propValue,
+    ...rest
+  } = props
+  const validation = useFieldValidation(csafPath)
+
+  const { handleChange } = useDebounceInput({
+    onChange: (e) => {
+      onValueChange?.(e.target.value)
+      onChange?.(e)
+    },
+    onBlur,
+    value: propValue as string,
+  })
+
+  return (
+    <HeroUIAutocomplete
+      labelPlacement={labelPlacement ?? 'outside'}
+      placeholder={placeholder ?? ' '}
+      variant={variant ?? 'bordered'}
+      inputProps={{
+        classNames: {
+          inputWrapper: 'border-1 shadow-none',
+        },
+      }}
+      onChange={handleChange}
+      errorMessage={validation.errorMessages.map((m) => m.message).join(', ')}
+      isInvalid={validation.hasErrors && (isTouched || validation.isTouched)}
+      {...rest}
+    />
+  )
+}

--- a/src/routes/vulnerabilities/General.tsx
+++ b/src/routes/vulnerabilities/General.tsx
@@ -1,8 +1,12 @@
 import HSplit from '@/components/forms/HSplit'
 import { Input } from '@/components/forms/Input'
 import VSplit from '@/components/forms/VSplit'
-import { TVulnerability } from './types/tVulnerability'
+import { TCwe, TVulnerability } from './types/tVulnerability'
 import { checkReadOnly } from '@/utils/template'
+import { Autocomplete } from '@/components/forms/Autocomplete'
+import { useMemo } from 'react'
+import { weaknesses } from '@secvisogram/csaf-validator-lib/cwe.js'
+import { AutocompleteItem } from '@heroui/react'
 
 export default function General({
   vulnerability,
@@ -15,6 +19,8 @@ export default function General({
   onChange: (vulnerability: TVulnerability) => void
   isTouched?: boolean
 }) {
+  const cwes = useMemo<TCwe[]>(() => weaknesses, [])
+
   return (
     <VSplit>
       <HSplit>
@@ -29,16 +35,23 @@ export default function General({
           autoFocus
           isDisabled={checkReadOnly(vulnerability, 'cve')}
         />
-        <Input
+        <Autocomplete
           label="CWE"
           csafPath={`/vulnerabilities/${vulnerabilityIndex}/cwe/name`}
           isTouched={isTouched}
-          value={vulnerability.cwe}
-          onValueChange={(newValue) =>
-            onChange({ ...vulnerability, cwe: newValue })
-          }
+          defaultSelectedKey={vulnerability.cwe?.id}
+          onSelectionChange={(selected) => {
+            onChange({
+              ...vulnerability,
+              cwe: cwes.find((x) => x.id === (selected as string)),
+            })
+          }}
           isDisabled={checkReadOnly(vulnerability, 'cwe')}
-        />
+        >
+          {cwes.map((cwe) => (
+            <AutocompleteItem key={cwe.id}>{cwe.name}</AutocompleteItem>
+          ))}
+        </Autocomplete>
       </HSplit>
       <Input
         label="Title"

--- a/src/routes/vulnerabilities/types/tVulnerability.ts
+++ b/src/routes/vulnerabilities/types/tVulnerability.ts
@@ -2,10 +2,15 @@ import { TNote } from '@/routes/shared/NotesList'
 import { uid } from 'uid'
 import { TVulnerabilityProduct } from './tVulnerabilityProduct'
 
+export type TCwe = {
+  id: string
+  name: string
+}
+
 export type TVulnerability = {
   id: string
   cve: string
-  cwe: string
+  cwe?: TCwe
   title: string
   notes: TNote[]
   products: TVulnerabilityProduct[]
@@ -15,7 +20,6 @@ export function getDefaultVulnerability(): TVulnerability {
   return {
     id: uid(),
     cve: '',
-    cwe: '',
     title: '',
     notes: [] as TNote[],
     products: [] as TVulnerabilityProduct[],

--- a/src/types/csaf-validator-lib.d.ts
+++ b/src/types/csaf-validator-lib.d.ts
@@ -24,3 +24,7 @@ declare module '@secvisogram/csaf-validator-lib/validate.js' {
 }
 
 declare module '@secvisogram/csaf-validator-lib/basic.js'
+
+declare module '@secvisogram/csaf-validator-lib/cwe.js' {
+  export const weaknesses: { id: string; name: string }[]
+}

--- a/src/utils/csafExport/csafExport.ts
+++ b/src/utils/csafExport/csafExport.ts
@@ -57,11 +57,12 @@ export function createCSAFDocument(documentStore: TDocumentStore) {
       (vulnerability) => ({
         cve: vulnerability.cve,
         title: vulnerability.title,
-        cwe: {
-          // TODO: add further CWE support
-          id: 'not supported by sec-o-simple yet',
-          name: vulnerability.cwe,
-        },
+        cwe: vulnerability.cwe
+          ? {
+              id: vulnerability.cwe.id,
+              name: vulnerability.cwe.name,
+            }
+          : undefined,
         notes: vulnerability.notes.map(parseNote),
         product_status: {
           known_affected: vulnerability.products.map((p) =>


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description

- The CWE field in the Vulnerabilities section is now a autocomplete that is connected with the CWE list in the `csaf-validator-lib` library.
- CWE information in the csaf export is now valid

![image](https://github.com/user-attachments/assets/0fb14433-8a16-49b6-823e-61ae674e23c5)


## Related Tickets & Documents

Fixes https://github.com/sec-o-simple/sec-o-simple/issues/9
