### PR TITLE
feat: show id in CWE selection

### DIFF
--- a/src/routes/vulnerabilities/General.tsx
+++ b/src/routes/vulnerabilities/General.tsx
@@ -49,7 +49,12 @@ export default function General({
           isDisabled={checkReadOnly(vulnerability, 'cwe')}
         >
           {cwes.map((cwe) => (
-            <AutocompleteItem key={cwe.id}>{cwe.name}</AutocompleteItem>
+            <AutocompleteItem
+              key={cwe.id}
+              textValue={`${cwe.id} - ${cwe.name}`}
+            >
+              {cwe.id} - {cwe.name}
+            </AutocompleteItem>
           ))}
         </Autocomplete>
       </HSplit>


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
The CWE input field now also contains the CWE id, which can now also be searched for
![image](https://github.com/user-attachments/assets/25b495e0-186c-47c2-a39f-7f35479a2586)

