### PR TITLE
fix: Use same version of internationalized/date among packages for now

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@heroui/table": "^2.2.12",
         "@heroui/tabs": "^2.2.11",
         "@heroui/theme": "^2.4.9",
-        "@internationalized/date": "^3.8.0",
+        "@internationalized/date": "3.8.0",
         "@secvisogram/csaf-validator-lib": "^1.3.50",
         "motion": "^12.4.7",
         "react": "18.3.1",
@@ -955,15 +955,6 @@
         "react-dom": ">=18 || >=19.0.0-rc.0"
       }
     },
-    "node_modules/@heroui/calendar/node_modules/@internationalized/date": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.0.tgz",
-      "integrity": "sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
     "node_modules/@heroui/card": {
       "version": "2.2.18",
       "resolved": "https://registry.npmjs.org/@heroui/card/-/card-2.2.18.tgz",
@@ -1077,15 +1068,6 @@
         "react-dom": ">=18 || >=19.0.0-rc.0"
       }
     },
-    "node_modules/@heroui/date-input/node_modules/@internationalized/date": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.0.tgz",
-      "integrity": "sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
     "node_modules/@heroui/date-picker": {
       "version": "2.3.19",
       "resolved": "https://registry.npmjs.org/@heroui/date-picker/-/date-picker-2.3.19.tgz",
@@ -1117,15 +1099,6 @@
         "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
         "react": ">=18 || >=19.0.0-rc.0",
         "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@heroui/date-picker/node_modules/@internationalized/date": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.0.tgz",
-      "integrity": "sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@heroui/divider": {
@@ -1911,15 +1884,6 @@
         "react": ">=18 || >=19.0.0-rc.0"
       }
     },
-    "node_modules/@heroui/system/node_modules/@internationalized/date": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.0.tgz",
-      "integrity": "sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
     "node_modules/@heroui/table": {
       "version": "2.2.18",
       "resolved": "https://registry.npmjs.org/@heroui/table/-/table-2.2.18.tgz",
@@ -2369,9 +2333,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@internationalized/date": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.1.tgz",
-      "integrity": "sha512-PgVE6B6eIZtzf9Gu5HvJxRK3ufUFz9DhspELuhW/N0GuMGMTLvPQNRkHP2hTuP9lblOk+f+1xi96sPiPXANXAA==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.0.tgz",
+      "integrity": "sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
@@ -2873,6 +2837,15 @@
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
+    "node_modules/@react-aria/grid/node_modules/@internationalized/date": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.1.tgz",
+      "integrity": "sha512-PgVE6B6eIZtzf9Gu5HvJxRK3ufUFz9DhspELuhW/N0GuMGMTLvPQNRkHP2hTuP9lblOk+f+1xi96sPiPXANXAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
     "node_modules/@react-aria/grid/node_modules/@react-aria/focus": {
       "version": "3.20.3",
       "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.20.3.tgz",
@@ -3337,6 +3310,15 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton/node_modules/@internationalized/date": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.1.tgz",
+      "integrity": "sha512-PgVE6B6eIZtzf9Gu5HvJxRK3ufUFz9DhspELuhW/N0GuMGMTLvPQNRkHP2hTuP9lblOk+f+1xi96sPiPXANXAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@react-aria/spinbutton/node_modules/@react-aria/i18n": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@heroui/table": "^2.2.12",
     "@heroui/tabs": "^2.2.11",
     "@heroui/theme": "^2.4.9",
-    "@internationalized/date": "^3.8.0",
+    "@internationalized/date": "3.8.0",
     "@secvisogram/csaf-validator-lib": "^1.3.50",
     "motion": "^12.4.7",
     "react": "18.3.1",


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description

Builds currently fail due to an inconsistency within the usage of `@internationalized/date`. This PR sets a specific version for the package.