### PR TITLE
Feat/csaf import

### DIFF
--- a/src/components/layout/TopBarLayout.tsx
+++ b/src/components/layout/TopBarLayout.tsx
@@ -1,5 +1,5 @@
 import { useCSAFExport } from '@/utils/csafExport/csafExport'
-import { useSOSExport } from '@/utils/csafExport/sosDraft'
+import { useSOSExport } from '@/utils/sosDraft'
 import useValidationStore from '@/utils/useValidationStore'
 import {
   faAdd,

--- a/src/routes/document-selection/EditDocument.tsx
+++ b/src/routes/document-selection/EditDocument.tsx
@@ -1,4 +1,4 @@
-import { useSOSImport } from '@/utils/csafExport/sosDraft'
+import { useSOSImport } from '@/utils/sosDraft'
 import { faArrowRight, faEdit } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button } from '@heroui/button'

--- a/src/utils/csafExport/csafExport.ts
+++ b/src/utils/csafExport/csafExport.ts
@@ -6,6 +6,8 @@ import { parseNote } from './parseNote'
 import { parseProductTreeBranches } from './parseProductTreeBranches'
 import { PidGenerator } from './pidGenerator'
 
+export type TCSAFDocument = ReturnType<typeof createCSAFDocument>
+
 export function createCSAFDocument(documentStore: TDocumentStore) {
   const pidGenerator = new PidGenerator()
   const currentDate = new Date().toISOString()

--- a/src/utils/csafImport/csafImport.ts
+++ b/src/utils/csafImport/csafImport.ts
@@ -1,0 +1,139 @@
+import {
+  TDocumentInformation,
+  getDefaultDocumentInformation,
+} from '@/routes/document-information/types/tDocumentInformation'
+import { SOSDraft, useSOSImport } from '../sosDraft'
+import { TSOSDocumentType } from '../useDocumentStore'
+import { TCSAFDocument } from '../csafExport/csafExport'
+import {
+  TDocumentPublisher,
+  TPublisherCategory,
+} from '@/routes/document-information/types/tDocumentPublisher'
+import { DeepPartial } from '../deepPartial'
+import {
+  TDocumentReference,
+  getDefaultDocumentReference,
+} from '@/routes/document-information/types/tDocumentReference'
+import { parseNote } from './parseNote'
+import { TNote } from '@/routes/shared/NotesList'
+import { TParsedNote } from '../csafExport/parseNote'
+import { IdGenerator } from './idGenerator'
+import { TProductTreeBranch } from '@/routes/products/types/tProductTreeBranch'
+import { parseProductTree } from './parseProductTree'
+import { parseVulnerabilities } from './parseVulnerabilities'
+import {
+  CSAFRelationship,
+  TRelationship,
+} from '@/routes/products/types/tRelationship'
+import { TVulnerability } from '@/routes/vulnerabilities/types/tVulnerability'
+import { parseRelationships } from './parseRelationships'
+
+export const supportedCSAFVersions = ['2.0']
+
+export function parseCSAFDocument(
+  csafDocument: DeepPartial<TCSAFDocument>,
+): SOSDraft | undefined {
+  const idGenerator = new IdGenerator()
+  // TODO: generate type dynamically
+  const sosDocumentType: TSOSDocumentType = 'HardwareSoftware'
+
+  const defaultDocumentInformation = getDefaultDocumentInformation()
+  const csafDoc = csafDocument.document
+  const documentInformation: TDocumentInformation = {
+    id: csafDoc?.tracking?.id || defaultDocumentInformation.id,
+    language: csafDoc?.lang ?? defaultDocumentInformation.language,
+    title: csafDoc?.title ?? defaultDocumentInformation.title,
+    publisher: {
+      name:
+        csafDoc?.publisher?.name ?? defaultDocumentInformation.publisher.name,
+      category:
+        (csafDoc?.publisher?.category as TPublisherCategory) ??
+        defaultDocumentInformation.publisher.category,
+      namespace:
+        csafDoc?.publisher?.namespace ??
+        defaultDocumentInformation.publisher.namespace,
+      contactDetails:
+        csafDoc?.publisher?.contact_details ??
+        defaultDocumentInformation.publisher.contactDetails,
+      issuingAuthority:
+        csafDoc?.publisher?.issuing_authority ??
+        defaultDocumentInformation.publisher.issuingAuthority,
+    } as TDocumentPublisher,
+    notes:
+      csafDoc?.notes?.map((note) => parseNote(note as TParsedNote)) ??
+      ([] as TNote[]),
+    references:
+      csafDoc?.references?.map((reference) => {
+        const defaultReference = getDefaultDocumentReference()
+        return {
+          id: defaultReference.id,
+          summary: reference?.summary ?? defaultReference.summary,
+          url: reference?.url ?? defaultReference.url,
+        } as TDocumentReference
+      }) ?? ([] as TDocumentReference[]),
+  }
+
+  const products: TProductTreeBranch[] = parseProductTree(
+    csafDocument as TCSAFDocument,
+    idGenerator,
+  )
+
+  const relationships: TRelationship[] = parseRelationships(
+    (csafDocument.product_tree?.relationships ?? []) as CSAFRelationship[],
+    idGenerator,
+    products,
+  )
+
+  const vulnerabilities: TVulnerability[] = parseVulnerabilities(
+    csafDocument as TCSAFDocument,
+    idGenerator,
+    products,
+  )
+
+  return {
+    sosDocumentType,
+    documentInformation,
+    products,
+    relationships,
+    vulnerabilities,
+  }
+}
+
+export function useCSAFImport() {
+  const { importSOSDraft } = useSOSImport()
+
+  const getCSAFDocumentVersion = (
+    documentObject: object,
+  ): string | undefined => {
+    if (
+      'document' in documentObject &&
+      documentObject.document !== null &&
+      typeof documentObject.document === 'object' &&
+      'csaf_version' in documentObject.document &&
+      typeof documentObject.document.csaf_version === 'string'
+    ) {
+      return documentObject.document.csaf_version
+    }
+  }
+
+  const isCSAFDocument = (documentObject: object): boolean => {
+    return getCSAFDocumentVersion(documentObject) !== undefined
+  }
+
+  const isCSAFVersionSupported = (documentObject: object): boolean => {
+    return supportedCSAFVersions.includes(
+      getCSAFDocumentVersion(documentObject) ?? 'NaV',
+    )
+  }
+
+  const importCSAFDocument = (csafDocument: object): boolean => {
+    const sosDocument = parseCSAFDocument(csafDocument)
+    if (sosDocument) {
+      importSOSDraft(sosDocument)
+      return true
+    }
+    return false
+  }
+
+  return { isCSAFDocument, isCSAFVersionSupported, importCSAFDocument }
+}

--- a/src/utils/csafImport/idGenerator.ts
+++ b/src/utils/csafImport/idGenerator.ts
@@ -1,0 +1,21 @@
+import { uid } from 'uid'
+
+export class IdGenerator {
+  previousGeneratedIds: { [key: string]: string } = {}
+
+  getId(csafPid?: string): string {
+    if (
+      csafPid &&
+      csafPid !== '' &&
+      this.previousGeneratedIds[csafPid] !== undefined
+    ) {
+      return this.previousGeneratedIds[csafPid]
+    } else {
+      const newId = uid()
+      if (csafPid) {
+        this.previousGeneratedIds[csafPid] = newId
+      }
+      return newId
+    }
+  }
+}

--- a/src/utils/csafImport/parseNote.ts
+++ b/src/utils/csafImport/parseNote.ts
@@ -1,0 +1,12 @@
+import { TNote } from '@/routes/shared/NotesList'
+import { TParsedNote } from '../csafExport/parseNote'
+import { uid } from 'uid'
+
+export function parseNote(csafNote: TParsedNote): TNote {
+  return {
+    id: uid(),
+    category: csafNote.category,
+    title: csafNote.title,
+    content: csafNote.text,
+  }
+}

--- a/src/utils/csafImport/parseProductTree.ts
+++ b/src/utils/csafImport/parseProductTree.ts
@@ -1,0 +1,38 @@
+import {
+  TProductTreeBranch,
+  getDefaultProductTreeBranch,
+} from '@/routes/products/types/tProductTreeBranch'
+import { TCSAFDocument } from '../csafExport/csafExport'
+import { DeepPartial } from '../deepPartial'
+import { IdGenerator } from './idGenerator'
+import { TParsedProductTreeBranch } from '../csafExport/parseProductTreeBranches'
+
+function convertCSAFProductTreeBranches(
+  csafPTBs: TParsedProductTreeBranch[],
+  idGenerator: IdGenerator,
+): TProductTreeBranch[] {
+  return csafPTBs.map((csafPTB) => {
+    const defaultPTB = getDefaultProductTreeBranch(csafPTB.category)
+    return {
+      id: idGenerator.getId(csafPTB.product?.product_id),
+      category: csafPTB.category,
+      name: csafPTB.name || defaultPTB.name,
+      description: csafPTB.product?.name ?? defaultPTB.description,
+      subBranches: convertCSAFProductTreeBranches(
+        csafPTB.branches ?? [],
+        idGenerator,
+      ),
+      type: defaultPTB.type,
+    } as TProductTreeBranch
+  })
+}
+
+export function parseProductTree(
+  csafDocument: DeepPartial<TCSAFDocument>,
+  idGenerator: IdGenerator,
+): TProductTreeBranch[] {
+  return convertCSAFProductTreeBranches(
+    csafDocument.product_tree?.branches as TParsedProductTreeBranch[],
+    idGenerator,
+  )
+}

--- a/src/utils/csafImport/parseRelationships.ts
+++ b/src/utils/csafImport/parseRelationships.ts
@@ -1,0 +1,54 @@
+import {
+  CSAFRelationship,
+  TRelationship,
+  getDefaultRelationship,
+} from '@/routes/products/types/tRelationship'
+import { getParentPTB } from './utils'
+import { TProductTreeBranch } from '@/routes/products/types/tProductTreeBranch'
+import { IdGenerator } from './idGenerator'
+
+export function parseRelationships(
+  csafRelationships: CSAFRelationship[],
+  idGenerator: IdGenerator,
+  sosPTBs: TProductTreeBranch[],
+): TRelationship[] {
+  const relationships: TRelationship[] = []
+
+  for (const csafRelationship of csafRelationships) {
+    const id1 = idGenerator.getId(csafRelationship.product_reference)
+    const id2 = idGenerator.getId(csafRelationship.relates_to_product_reference)
+    const parent1 = getParentPTB(id1, sosPTBs)?.id
+    const parent2 = getParentPTB(id2, sosPTBs)?.id
+
+    if (!parent1 || !parent2) {
+      console.error('Failed to parse csaf relationship', csafRelationship)
+      continue
+    }
+
+    const existingElement = relationships.find(
+      (x) =>
+        x.category === csafRelationship.category &&
+        x.productId1 === parent1 &&
+        x.productId2 === parent2,
+    )
+    const relationship = existingElement ?? {
+      ...getDefaultRelationship(),
+      productId1: parent1,
+      productId2: parent2,
+      category: csafRelationship.category,
+    }
+    relationship.name += csafRelationship.full_product_name.name
+    if (!relationship.product1VersionIds.includes(id1)) {
+      relationship.product1VersionIds.push(id1)
+    }
+    if (!relationship.product2VersionIds.includes(id2)) {
+      relationship.product2VersionIds.push(id2)
+    }
+
+    if (!existingElement) {
+      relationships.push(relationship)
+    }
+  }
+
+  return relationships
+}

--- a/src/utils/csafImport/parseVulnerabilities.ts
+++ b/src/utils/csafImport/parseVulnerabilities.ts
@@ -1,0 +1,74 @@
+import {
+  TCwe,
+  TVulnerability,
+  getDefaultVulnerability,
+} from '@/routes/vulnerabilities/types/tVulnerability'
+import { TCSAFDocument } from '../csafExport/csafExport'
+import { IdGenerator } from './idGenerator'
+import { parseNote } from './parseNote'
+import { TParsedNote } from '../csafExport/parseNote'
+import {
+  TRemediation,
+  getDefaultRemediation,
+} from '@/routes/vulnerabilities/types/tRemediation'
+import {
+  TVulnerabilityScore,
+  getDefaultVulnerabilityScore,
+} from '@/routes/vulnerabilities/types/tVulnerabilityScore'
+import { TProductTreeBranch } from '@/routes/products/types/tProductTreeBranch'
+import { parseVulnerabilityProducts } from './parseVulnerabilityProducts'
+
+export function parseVulnerabilities(
+  csafDocument: TCSAFDocument,
+  idGenerator: IdGenerator,
+  ptbs: TProductTreeBranch[],
+): TVulnerability[] {
+  return csafDocument.vulnerabilities.map((vulnerability) => {
+    const defaultVulnerability = getDefaultVulnerability()
+    return {
+      id: defaultVulnerability.id,
+      cve: vulnerability.cve ?? defaultVulnerability.cve,
+      cwe: vulnerability.cwe as TCwe | undefined,
+      title: vulnerability.title ?? defaultVulnerability.title,
+      notes: vulnerability.notes.map((note) => parseNote(note as TParsedNote)),
+      products: parseVulnerabilityProducts(
+        vulnerability.product_status,
+        idGenerator,
+        ptbs,
+      ),
+      remediations: vulnerability.remediations.map((remediation) => {
+        const defaultRemediation = getDefaultRemediation()
+        return {
+          id: defaultRemediation.id,
+          category: remediation.category ?? defaultRemediation.category,
+          date: remediation.date ?? defaultRemediation.date,
+          details: remediation.details ?? defaultRemediation.details,
+          url: remediation.url ?? defaultRemediation.url,
+          productIds: remediation.product_ids.map((id) =>
+            idGenerator.getId(id),
+          ),
+        } as TRemediation
+      }),
+      scores: vulnerability.scores.map((score) => {
+        const defaultScore = getDefaultVulnerabilityScore()
+
+        const cvssVersion =
+          Object.keys(score).find((x) => x.startsWith('cvss_')) ?? 'cvss_v3'
+
+        const cvssInfos = (score as { [key: string]: unknown })[cvssVersion] as
+          | undefined
+          | {
+              version: string
+              vectorString: string
+            }
+
+        return {
+          id: defaultScore.id,
+          productIds: score.products.map((id) => idGenerator.getId(id)),
+          cvssVersion: cvssInfos?.version ?? defaultScore.cvssVersion,
+          vectorString: cvssInfos?.vectorString ?? defaultScore.vectorString,
+        } as TVulnerabilityScore
+      }),
+    } as TVulnerability
+  })
+}

--- a/src/utils/csafImport/parseVulnerabilityProducts.ts
+++ b/src/utils/csafImport/parseVulnerabilityProducts.ts
@@ -1,0 +1,55 @@
+import { getDefaultVulnerabilityProduct } from '@/routes/vulnerabilities/types/tVulnerabilityProduct'
+import { TProductTreeBranch } from '@/routes/products/types/tProductTreeBranch'
+import { TCSAFDocument } from '../csafExport/csafExport'
+import { TVulnerabilityProduct } from '@/routes/vulnerabilities/types/tVulnerabilityProduct'
+import { IdGenerator } from './idGenerator'
+import { getParentPTB } from './utils'
+
+export function parseVulnerabilityProducts(
+  productStatus: TCSAFDocument['vulnerabilities'][number]['product_status'],
+  idGenerator: IdGenerator,
+  sosPtbs: TProductTreeBranch[],
+): TVulnerabilityProduct[] {
+  let vulnerabilityProducts: TVulnerabilityProduct[] = []
+  const addVulnerabilityProduct = (
+    productId: string,
+    versionId: string,
+    category: 'affected' | 'fixed',
+  ) => {
+    let previousVP = vulnerabilityProducts.find(
+      (x) => x.productId === productId,
+    )
+
+    let newVP = previousVP
+      ? previousVP
+      : { ...getDefaultVulnerabilityProduct(), productId }
+
+    if (category === 'affected') {
+      newVP.firstAffectedVersionId = versionId
+    } else {
+      newVP.firstFixedVersionId = versionId
+    }
+
+    if (!previousVP) {
+      vulnerabilityProducts.push(newVP)
+    }
+  }
+
+  productStatus.known_affected.map((id) => {
+    const ptbId = idGenerator.getId(id)
+    const parentId = getParentPTB(ptbId, sosPtbs)?.id
+    if (parentId) {
+      addVulnerabilityProduct(parentId, ptbId, 'affected')
+    }
+  })
+
+  productStatus.fixed.map((id) => {
+    const ptbId = idGenerator.getId(id)
+    const parentId = getParentPTB(ptbId, sosPtbs)?.id
+    if (parentId) {
+      addVulnerabilityProduct(parentId, ptbId, 'fixed')
+    }
+  })
+
+  return vulnerabilityProducts
+}

--- a/src/utils/csafImport/utils.ts
+++ b/src/utils/csafImport/utils.ts
@@ -1,0 +1,18 @@
+import { TProductTreeBranch } from '@/routes/products/types/tProductTreeBranch'
+
+export function getParentPTB(
+  id: string,
+  startingBranches: TProductTreeBranch[],
+  currentParent?: TProductTreeBranch,
+): TProductTreeBranch | undefined {
+  for (const branch of startingBranches) {
+    if (startingBranches?.find((x) => x.id === id)) {
+      return currentParent
+    } else {
+      const nestedSearch = getParentPTB(id, branch.subBranches, branch)
+      if (nestedSearch) {
+        return nestedSearch
+      }
+    }
+  }
+}

--- a/src/utils/deepPartial.ts
+++ b/src/utils/deepPartial.ts
@@ -1,0 +1,5 @@
+export type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>
+    }
+  : T

--- a/src/utils/sosDraft.ts
+++ b/src/utils/sosDraft.ts
@@ -98,15 +98,19 @@ export function useSOSImport() {
   const importSOSDocument = (jsonObject: object): boolean => {
     const sosDraft = getSOSDraft(jsonObject)
     if (sosDraft) {
-      setSOSDocumentType(sosDraft.sosDocumentType)
-      updateDocumentInformation(sosDraft.documentInformation)
-      updateProducts(sosDraft.products)
-      updateRelationships(sosDraft.relationships)
-      updateVulnerabilities(sosDraft.vulnerabilities)
+      importSOSDraft(sosDraft)
       return true
     }
     return false
   }
 
-  return { isSOSDraft, importSOSDocument }
+  const importSOSDraft = (sosDraft: SOSDraft) => {
+    setSOSDocumentType(sosDraft.sosDocumentType)
+    updateDocumentInformation(sosDraft.documentInformation)
+    updateProducts(sosDraft.products)
+    updateRelationships(sosDraft.relationships)
+    updateVulnerabilities(sosDraft.vulnerabilities)
+  }
+
+  return { isSOSDraft, importSOSDocument, importSOSDraft }
 }

--- a/src/utils/sosDraft.ts
+++ b/src/utils/sosDraft.ts
@@ -1,10 +1,10 @@
 import { TDocumentInformation } from '@/routes/document-information/types/tDocumentInformation'
-import { download } from '../download'
+import { download } from './download'
 import useDocumentStore, {
   TSOSDocumentType,
   sosDocumentTypes,
-} from '../useDocumentStore'
-import { getFilename } from './helpers'
+} from './useDocumentStore'
+import { getFilename } from './csafExport/helpers'
 import { TProductTreeBranch } from '@/routes/products/types/tProductTreeBranch'
 import { TVulnerability } from '@/routes/vulnerabilities/types/tVulnerability'
 import { TRelationship } from '@/routes/products/types/tRelationship'
@@ -98,7 +98,6 @@ export function useSOSImport() {
   const importSOSDocument = (jsonObject: object): boolean => {
     const sosDraft = getSOSDraft(jsonObject)
     if (sosDraft) {
-      console.log(sosDraft)
       setSOSDocumentType(sosDraft.sosDocumentType)
       updateDocumentInformation(sosDraft.documentInformation)
       updateProducts(sosDraft.products)


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
Adds csaf imports.
When creating a new document, the user can now upload a csaf document, which will then be imported.
Sec-o-simple automatically detects whether the uploaded json file is a sec-o-simple file, a csaf file or an invalid json file.

