### PR TITLE
Fix/edit product type selection

### DIFF
--- a/src/components/layout/TopBarLayout.tsx
+++ b/src/components/layout/TopBarLayout.tsx
@@ -34,7 +34,12 @@ function ValidationErrorList() {
 
   return (
     <>
-      <Modal isOpen={isOpen} size={'full'} onClose={onClose}>
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+        scrollBehavior="inside"
+        size="full"
+      >
         <ModalContent>
           {(onClose) => (
             <>

--- a/src/routes/products/components/PTBEditForm.tsx
+++ b/src/routes/products/components/PTBEditForm.tsx
@@ -15,6 +15,7 @@ import {
 import { checkReadOnly, getPlaceholder } from '@/utils/template'
 import Select from '@/components/forms/Select'
 import { SelectItem } from '@heroui/select'
+import useDocumentStore from '@/utils/useDocumentStore'
 
 export type PTBEditFormProps = {
   ptb?: TProductTreeBranch
@@ -25,6 +26,7 @@ export function PTBEditForm({ ptb, onSave }: PTBEditFormProps) {
   const [name, setName] = useState(ptb?.name ?? '')
   const [description, setDescription] = useState(ptb?.description ?? '')
   const [type, setType] = useState(ptb?.type ?? 'Software')
+  const sosDocumentType = useDocumentStore((state) => state.sosDocumentType)
 
   const categoryLabel =
     ptb?.category === 'vendor'
@@ -59,15 +61,20 @@ export function PTBEditForm({ ptb, onSave }: PTBEditFormProps) {
               <Select
                 label="Type"
                 selectedKeys={[type ?? 'Software']}
-                onSelectionChange={(selected) => {
-                  setType([...selected][0] as TProductTreeBranchProductType)
+                onChange={(e) => {
+                  if (!e.target.value) {
+                    return
+                  }
+                  setType(e.target.value as TProductTreeBranchProductType)
                 }}
                 isDisabled={!ptb || checkReadOnly(ptb, 'type')}
                 placeholder={ptb ? getPlaceholder(ptb, 'type') : undefined}
               >
-                {productTreeBranchProductTypes.map((type) => (
-                  <SelectItem key={type}>{type}</SelectItem>
-                ))}
+                {productTreeBranchProductTypes
+                  .filter((type) => sosDocumentType.includes(type))
+                  .map((type) => (
+                    <SelectItem key={type}>{type}</SelectItem>
+                  ))}
               </Select>
             )}
           </ModalBody>


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
Selectable product types are now determined by the documentType, aligning the behavior with the products section.
In the edit form, users are now required to select a productType, ensuring that a valid option is always chosen.
Previously, when errors in the new modal overflowed the visible area, the content was not scrollable. This issue has now been resolved.

## Related Tickets & Documents

- Closes #38 
