### PR TITLE
fix data mapping for imported files that don't have the expected arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview",
     "test": "npm run lint && cypress run",
     "lint": "eslint .",
-    "format": "eslint --fix ."
+    "lint:fix": "eslint --fix ."
   },
   "dependencies": {
     "@fortawesome/free-regular-svg-icons": "^6.7.2",

--- a/src/utils/csafImport/parseProductTree.ts
+++ b/src/utils/csafImport/parseProductTree.ts
@@ -11,20 +11,22 @@ function convertCSAFProductTreeBranches(
   csafPTBs: TParsedProductTreeBranch[],
   idGenerator: IdGenerator,
 ): TProductTreeBranch[] {
-  return csafPTBs.map((csafPTB) => {
-    const defaultPTB = getDefaultProductTreeBranch(csafPTB.category)
-    return {
-      id: idGenerator.getId(csafPTB.product?.product_id),
-      category: csafPTB.category,
-      name: csafPTB.name || defaultPTB.name,
-      description: csafPTB.product?.name ?? defaultPTB.description,
-      subBranches: convertCSAFProductTreeBranches(
-        csafPTB.branches ?? [],
-        idGenerator,
-      ),
-      type: defaultPTB.type,
-    } as TProductTreeBranch
-  })
+  return (
+    csafPTBs?.map((csafPTB) => {
+      const defaultPTB = getDefaultProductTreeBranch(csafPTB.category)
+      return {
+        id: idGenerator.getId(csafPTB.product?.product_id),
+        category: csafPTB.category,
+        name: csafPTB.name || defaultPTB.name,
+        description: csafPTB.product?.name ?? defaultPTB.description,
+        subBranches: convertCSAFProductTreeBranches(
+          csafPTB.branches ?? [],
+          idGenerator,
+        ),
+        type: defaultPTB.type,
+      } as TProductTreeBranch
+    }) || []
+  )
 }
 
 export function parseProductTree(

--- a/src/utils/csafImport/parseRelationships.ts
+++ b/src/utils/csafImport/parseRelationships.ts
@@ -37,7 +37,7 @@ export function parseRelationships(
       productId2: parent2,
       category: csafRelationship.category,
     }
-    relationship.name += csafRelationship.full_product_name.name
+    relationship.name += csafRelationship.full_product_name?.name
     if (!relationship.product1VersionIds.includes(id1)) {
       relationship.product1VersionIds.push(id1)
     }

--- a/src/utils/csafImport/parseVulnerabilities.ts
+++ b/src/utils/csafImport/parseVulnerabilities.ts
@@ -23,52 +23,58 @@ export function parseVulnerabilities(
   idGenerator: IdGenerator,
   ptbs: TProductTreeBranch[],
 ): TVulnerability[] {
-  return csafDocument.vulnerabilities.map((vulnerability) => {
-    const defaultVulnerability = getDefaultVulnerability()
-    return {
-      id: defaultVulnerability.id,
-      cve: vulnerability.cve ?? defaultVulnerability.cve,
-      cwe: vulnerability.cwe as TCwe | undefined,
-      title: vulnerability.title ?? defaultVulnerability.title,
-      notes: vulnerability.notes.map((note) => parseNote(note as TParsedNote)),
-      products: parseVulnerabilityProducts(
-        vulnerability.product_status,
-        idGenerator,
-        ptbs,
-      ),
-      remediations: vulnerability.remediations.map((remediation) => {
-        const defaultRemediation = getDefaultRemediation()
-        return {
-          id: defaultRemediation.id,
-          category: remediation.category ?? defaultRemediation.category,
-          date: remediation.date ?? defaultRemediation.date,
-          details: remediation.details ?? defaultRemediation.details,
-          url: remediation.url ?? defaultRemediation.url,
-          productIds: remediation.product_ids.map((id) =>
-            idGenerator.getId(id),
-          ),
-        } as TRemediation
-      }),
-      scores: vulnerability.scores.map((score) => {
-        const defaultScore = getDefaultVulnerabilityScore()
+  return (
+    csafDocument.vulnerabilities?.map((vulnerability) => {
+      const defaultVulnerability = getDefaultVulnerability()
+      return {
+        id: defaultVulnerability.id,
+        cve: vulnerability.cve ?? defaultVulnerability.cve,
+        cwe: vulnerability.cwe as TCwe | undefined,
+        title: vulnerability.title ?? defaultVulnerability.title,
+        notes: vulnerability.notes.map((note) =>
+          parseNote(note as TParsedNote),
+        ),
+        products: parseVulnerabilityProducts(
+          vulnerability.product_status,
+          idGenerator,
+          ptbs,
+        ),
+        remediations: vulnerability.remediations?.map((remediation) => {
+          const defaultRemediation = getDefaultRemediation()
+          return {
+            id: defaultRemediation.id,
+            category: remediation.category ?? defaultRemediation.category,
+            date: remediation.date ?? defaultRemediation.date,
+            details: remediation.details ?? defaultRemediation.details,
+            url: remediation.url ?? defaultRemediation.url,
+            productIds: remediation.product_ids.map((id) =>
+              idGenerator.getId(id),
+            ),
+          } as TRemediation
+        }),
+        scores: vulnerability.scores.map((score) => {
+          const defaultScore = getDefaultVulnerabilityScore()
 
-        const cvssVersion =
-          Object.keys(score).find((x) => x.startsWith('cvss_')) ?? 'cvss_v3'
+          const cvssVersion =
+            Object.keys(score).find((x) => x.startsWith('cvss_')) ?? 'cvss_v3'
 
-        const cvssInfos = (score as { [key: string]: unknown })[cvssVersion] as
-          | undefined
-          | {
-              version: string
-              vectorString: string
-            }
+          const cvssInfos = (score as { [key: string]: unknown })[
+            cvssVersion
+          ] as
+            | undefined
+            | {
+                version: string
+                vectorString: string
+              }
 
-        return {
-          id: defaultScore.id,
-          productIds: score.products.map((id) => idGenerator.getId(id)),
-          cvssVersion: cvssInfos?.version ?? defaultScore.cvssVersion,
-          vectorString: cvssInfos?.vectorString ?? defaultScore.vectorString,
-        } as TVulnerabilityScore
-      }),
-    } as TVulnerability
-  })
+          return {
+            id: defaultScore.id,
+            productIds: score.products.map((id) => idGenerator.getId(id)),
+            cvssVersion: cvssInfos?.version ?? defaultScore.cvssVersion,
+            vectorString: cvssInfos?.vectorString ?? defaultScore.vectorString,
+          } as TVulnerabilityScore
+        }),
+      } as TVulnerability
+    }) || []
+  )
 }

--- a/src/utils/csafImport/parseVulnerabilityProducts.ts
+++ b/src/utils/csafImport/parseVulnerabilityProducts.ts
@@ -34,8 +34,7 @@ export function parseVulnerabilityProducts(
       vulnerabilityProducts.push(newVP)
     }
   }
-
-  productStatus.known_affected.map((id) => {
+  productStatus.known_affected?.map((id) => {
     const ptbId = idGenerator.getId(id)
     const parentId = getParentPTB(ptbId, sosPtbs)?.id
     if (parentId) {
@@ -43,7 +42,7 @@ export function parseVulnerabilityProducts(
     }
   })
 
-  productStatus.fixed.map((id) => {
+  productStatus.fixed?.map((id) => {
     const ptbId = idGenerator.getId(id)
     const parentId = getParentPTB(ptbId, sosPtbs)?.id
     if (parentId) {
@@ -51,5 +50,5 @@ export function parseVulnerabilityProducts(
     }
   })
 
-  return vulnerabilityProducts
+  return vulnerabilityProducts || []
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
In the parsing algorithm for a imported file the objects were mapped to optimistically and are optional chained now, to ensure the mapping doesn't happen for undefined arrays.
The linting fix command was renamed to `lint:fix`.

## Related Tickets & Documents
- Closes #40 
