### PR TITLE
Fix/multiple vendors product creation

### DIFF
--- a/docs/io.github.sec-o-simple.example.json
+++ b/docs/io.github.sec-o-simple.example.json
@@ -51,6 +51,7 @@
             "category": "product_name",
             "name": "Product A",
             "description": "",
+            "type": "Software",
             "subBranches": [
               {
                 "id": "version1",

--- a/src/components/forms/PTBSelect.tsx
+++ b/src/components/forms/PTBSelect.tsx
@@ -5,6 +5,7 @@ import {
 import { useProductTreeBranch } from '@/utils/useProductTreeBranch'
 import { SelectItem, SelectProps } from '@heroui/select'
 import Select from './Select'
+import { getCategoryLabel } from '@/routes/products/components/PTBEditForm'
 
 type PTBSelectBaseProps = Omit<
   SelectProps,
@@ -40,6 +41,8 @@ export default function PTBSelect(props: PTBSelectProps) {
     (x) => !allowedIds || allowedIds.includes(x.id),
   )
 
+  const categoryLabel = getCategoryLabel(selectionCategory ?? '')
+
   return (
     <Select
       {...selectProps}
@@ -63,7 +66,9 @@ export default function PTBSelect(props: PTBSelectProps) {
       }}
     >
       {ptbs.map((p) => (
-        <SelectItem key={p.id}>{p.name}</SelectItem>
+        <SelectItem key={p.id}>
+          {p.name !== '' ? p.name : `Untitled ${categoryLabel}`}
+        </SelectItem>
       ))}
     </Select>
   )

--- a/src/routes/products/VendorList.tsx
+++ b/src/routes/products/VendorList.tsx
@@ -14,7 +14,7 @@ import { Modal, useDisclosure } from '@heroui/modal'
 import { faAdd, faEdit } from '@fortawesome/free-solid-svg-icons'
 
 export default function VendorList() {
-  const { rootBranch, addPTB, updatePTB, deletePTB, getPTBsByCategory } =
+  const { rootBranch, updatePTB, deletePTB, getPTBsByCategory } =
     useProductTreeBranch()
 
   const vendorListState = useListState<TProductTreeBranch>({
@@ -35,23 +35,14 @@ export default function VendorList() {
     localState: vendorListState.data,
     valueField: 'products',
     valueUpdater: 'updateProducts',
-    mergeUpdate: false,
+    mergeUpdate: true,
     init: (initialData) => {
       vendorListState.setData(
         getPTBsByCategory('vendor', Object.values(initialData)),
       )
     },
     // update PTBs manually to not overwrite root level items that are no vendors
-    shouldUpdate: (update) => {
-      Object.values(update).forEach((ptb) => {
-        if (rootBranch.some((x) => x.id === ptb.id)) {
-          updatePTB(ptb)
-        } else {
-          addPTB(ptb)
-        }
-      })
-      return false
-    },
+    shouldUpdate: () => true,
   })
 
   // modal variables

--- a/src/routes/products/components/PTBEditForm.tsx
+++ b/src/routes/products/components/PTBEditForm.tsx
@@ -21,19 +21,25 @@ export type PTBEditFormProps = {
   onSave?: (updatedPtb: TProductTreeBranch) => void
 }
 
+export function getCategoryLabel(category: string): string {
+  switch (category) {
+    case 'vendor':
+      return 'Vendor'
+    case 'product_name':
+      return 'Product'
+    case 'product_version':
+      return 'Product Version'
+    default:
+      return ''
+  }
+}
+
 export function PTBEditForm({ ptb, onSave }: PTBEditFormProps) {
   const [name, setName] = useState(ptb?.name ?? '')
   const [description, setDescription] = useState(ptb?.description ?? '')
   const [type, setType] = useState(ptb?.type ?? 'Software')
 
-  const categoryLabel =
-    ptb?.category === 'vendor'
-      ? 'Vendor'
-      : ptb?.category === 'product_name'
-        ? 'Product'
-        : ptb?.category === 'product_version'
-          ? 'Product Version'
-          : ''
+  const categoryLabel = getCategoryLabel(ptb?.category ?? '')
 
   return (
     <ModalContent>

--- a/src/routes/products/components/PTBEditForm.tsx
+++ b/src/routes/products/components/PTBEditForm.tsx
@@ -43,6 +43,7 @@ export function PTBEditForm({ ptb, onSave }: PTBEditFormProps) {
           <ModalBody>
             <Input
               label="Name"
+              autoFocus
               value={name}
               onValueChange={setName}
               isDisabled={!ptb || checkReadOnly(ptb, 'name')}

--- a/src/routes/vulnerabilities/components/VulnerabilityProduct.tsx
+++ b/src/routes/vulnerabilities/components/VulnerabilityProduct.tsx
@@ -42,7 +42,9 @@ export default function VulnerabilityProduct({
           placeholder={getPlaceholder(vulnerabilityProduct, 'productId')}
         >
           {productDetails.map((pd) => (
-            <SelectItem key={pd.productId}>{pd.productName}</SelectItem>
+            <SelectItem key={pd.productId}>
+              {pd.productName !== '' ? pd.productName : 'Untitled Product'}
+            </SelectItem>
           ))}
         </Select>
       </td>


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
To ensure that the vendorState and its product stay persistent the settings for the useDocumentStore had to be changed. Before that it could have led to unexpected behavior, especially when multiple vendors were used.
When the modal for editing a product is opened the default focus is on the first input field.
For the product selection within the vulnerabilities a default name of "Untitled Product" is shown.

## Related Tickets & Documents
- Closes #37 
