### PR TITLE
actually reset the document when a new document should be created

### DIFF
--- a/src/components/forms/ConfirmButton.tsx
+++ b/src/components/forms/ConfirmButton.tsx
@@ -1,0 +1,60 @@
+import { Button, ButtonProps } from '@heroui/button'
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  useDisclosure,
+} from '@heroui/react'
+
+type ConfirmButtonProps = {
+  confirmText: string
+  confirmTitle: string
+  onConfirm: () => void
+} & ButtonProps
+
+export default function ConfirmButton({
+  confirmText,
+  confirmTitle,
+  onConfirm,
+  ...props
+}: ConfirmButtonProps) {
+  const { isOpen, onOpen, onOpenChange } = useDisclosure()
+
+  return (
+    <>
+      <Button onPress={onOpen} fullWidth {...props}>
+        {props?.children || 'Confirm'}
+      </Button>
+      <Modal isOpen={isOpen} onOpenChange={onOpenChange} size="xl">
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader className="flex flex-col gap-1">
+                {confirmTitle || 'Confirm'}
+              </ModalHeader>
+              <ModalBody className="gap-4">
+                <p>{confirmText}</p>
+              </ModalBody>
+              <ModalFooter>
+                <Button variant="light" onPress={onClose}>
+                  Cancel
+                </Button>
+                <Button
+                  color="primary"
+                  onPress={() => {
+                    onConfirm()
+                    onClose()
+                  }}
+                >
+                  Confirm
+                </Button>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}

--- a/src/components/layout/TopBarLayout.tsx
+++ b/src/components/layout/TopBarLayout.tsx
@@ -1,5 +1,6 @@
 import { useCSAFExport } from '@/utils/csafExport/csafExport'
 import { useSOSExport } from '@/utils/sosDraft'
+import useDocumentStore from '@/utils/useDocumentStore'
 import useValidationStore from '@/utils/useValidationStore'
 import {
   faAdd,
@@ -27,6 +28,7 @@ import {
   useDisclosure,
 } from '@heroui/react'
 import { Outlet, useNavigate } from 'react-router'
+import ConfirmButton from '../forms/ConfirmButton'
 
 function ValidationErrorList() {
   const { messages } = useValidationStore()
@@ -85,7 +87,8 @@ export default function TopBarLayout() {
   const navigate = useNavigate()
   const { exportSOSDocument } = useSOSExport()
   const { exportCSAFDocument } = useCSAFExport()
-  const { isValid, isValidating } = useValidationStore()
+  const { isValid, isValidating, reset: resetValidation } = useValidationStore()
+  const { reset } = useDocumentStore()
 
   return (
     <div className="flex h-screen flex-col">
@@ -96,14 +99,21 @@ export default function TopBarLayout() {
             <p>Sec-o-simple</p>
           </span>
 
-          <Button
+          <ConfirmButton
             className="ml-4"
+            fullWidth={false}
             color="secondary"
-            onPress={() => navigate('/')}
+            confirmText="Are you sure you want to create a new document? This will reset the current document."
+            confirmTitle="Create New Document"
+            onConfirm={() => {
+              reset()
+              resetValidation()
+              navigate('/')
+            }}
           >
             <FontAwesomeIcon icon={faAdd} />
             New Document
-          </Button>
+          </ConfirmButton>
         </div>
         <div className="flex gap-3">
           <Button color="secondary" isDisabled={true}>

--- a/src/utils/useDocumentStore.ts
+++ b/src/utils/useDocumentStore.ts
@@ -32,6 +32,8 @@ export type TDocumentStore = {
   updateProducts: (update: TProductTreeBranch[]) => void
   updateRelationships: (update: TRelationship[]) => void
   updateVulnerabilities: (update: TVulnerability[]) => void
+
+  reset: () => void
 }
 
 const useDocumentStore = create<TDocumentStore>((set) => ({
@@ -53,6 +55,14 @@ const useDocumentStore = create<TDocumentStore>((set) => ({
   vulnerabilities: [],
   updateVulnerabilities: (update: TVulnerability[]) =>
     set({ vulnerabilities: update }),
+
+  reset: () =>
+    set({
+      documentInformation: getDefaultDocumentInformation(),
+      products: [],
+      relationships: [],
+      vulnerabilities: [],
+    }),
 }))
 
 export default useDocumentStore

--- a/src/utils/useValidationStore.ts
+++ b/src/utils/useValidationStore.ts
@@ -26,6 +26,8 @@ type ValidationStore = {
   visitPage: (path: string) => void
   hasVisitedPage: (path: string) => boolean
 
+  reset: () => void
+
   warnings: ValidationMessage[]
   infos: ValidationMessage[]
 }
@@ -66,6 +68,16 @@ const useValidationStore = create<ValidationStore>((set, get) => ({
     set((state) => ({
       touchedFields: new Set([...state.touchedFields, path]),
     })),
+
+  reset: () => {
+    set({
+      messages: [],
+      touchedFields: new Set(),
+      visitedPages: new Set(),
+      isValidating: false,
+      isValid: true,
+    })
+  },
 
   get errors() {
     return get().messages.filter((m) => m.severity === 'error')


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
For creating a new document a confirmation button was added. If this modal is confirmed, both the validation and the document is resetted and the user is redirected to the starting page.

## Related Tickets & Documents
- Closes #39 
