### PR TITLE
ensure that only one version is selected for scores and remeditations

### DIFF
--- a/src/components/WizardStep.tsx
+++ b/src/components/WizardStep.tsx
@@ -1,8 +1,8 @@
 import { Button } from '@heroui/button'
 import { PropsWithChildren } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import ProgressBar from './ProgressBar'
-import { useTranslation } from 'react-i18next'
 
 export type WizardStepProps = PropsWithChildren<{
   title?: string

--- a/src/components/forms/ProductSelect.tsx
+++ b/src/components/forms/ProductSelect.tsx
@@ -1,17 +1,19 @@
-import { SelectItem } from '@heroui/select'
-import Select from './Select'
 import { TProductTreeBranch } from '@/routes/products/types/tProductTreeBranch'
 import { useProductTreeBranch } from '@/utils/useProductTreeBranch'
+import { SelectItem } from '@heroui/select'
 import { useTranslation } from 'react-i18next'
+import Select from './Select'
 
 export type ProductSelectProps = {
   onAdd?: (product: TProductTreeBranch) => void
   isRequired?: boolean
+  selected?: string[]
 }
 
 export default function ProductSelect({
   onAdd,
   isRequired,
+  selected = [],
 }: ProductSelectProps) {
   const { getSelectablePTBs } = useProductTreeBranch()
   const ptbs = getSelectablePTBs()
@@ -32,9 +34,11 @@ export default function ProductSelect({
       }}
       isRequired={isRequired}
     >
-      {ptbs.map((p) => (
-        <SelectItem key={p.id}>{p.name}</SelectItem>
-      ))}
+      {ptbs
+        .filter((p) => !selected.includes(p.id))
+        .map((p) => (
+          <SelectItem key={p.id}>{p.name}</SelectItem>
+        ))}
     </Select>
   )
 }

--- a/src/routes/vulnerabilities/components/ProductsTagList.tsx
+++ b/src/routes/vulnerabilities/components/ProductsTagList.tsx
@@ -1,12 +1,12 @@
 import ProductSelect from '@/components/forms/ProductSelect'
 import VSplit from '@/components/forms/VSplit'
 import TagList from '@/routes/products/components/TagList'
-import { useEffect, useState } from 'react'
 import {
   TProductTreeBranchWithParents,
   getFullPTBName,
 } from '@/routes/products/types/tProductTreeBranch'
 import { useProductTreeBranch } from '@/utils/useProductTreeBranch'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 export type ProductsTagListProps = {
@@ -44,6 +44,7 @@ export default function ProductsTagList({
       </span>
       <ProductSelect
         isRequired={isRequired}
+        selected={selectedProducts.map((x) => x.id)}
         onAdd={(ptb) =>
           setSelectedProducts([
             ...new Set([


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
This change ensures that for remediations & scores a product version can only be selected once. This is simply done by providing all other selected versions to the select field.

## Related Tickets & Documents

- Closes #63 
