### PR TITLE
added field for tracking document status

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -66,7 +66,17 @@
       "general": {
         "title": "Dokumenttitel",
         "id": "Dokument-ID",
+        "state": "Status",
         "language": "Sprache",
+        "languages": {
+          "de": "Deutsch",
+          "en": "Englisch"
+        },
+        "status": {
+          "draft": "Entwurf",
+          "final": "Final",
+          "interim": "Zwischenstand"
+        },
         "revisionHistory": {
           "label": "Revision",
           "version": "Version",

--- a/locales/en.json
+++ b/locales/en.json
@@ -64,7 +64,17 @@
       "general": {
         "title": "Document Title",
         "id": "Document ID",
+        "state": "Status",
         "language": "Language",
+        "languages": {
+          "de": "German",
+          "en": "English"
+        },
+        "status": {
+          "draft": "Draft",
+          "final": "Final",
+          "interim": "Interim"
+        },
         "revisionHistory": {
           "label": "Revision",
           "version": "Version",

--- a/src/routes/document-information/General.tsx
+++ b/src/routes/document-information/General.tsx
@@ -1,19 +1,20 @@
 import WizardStep from '@/components/WizardStep'
 import HSplit from '@/components/forms/HSplit'
 import { Input } from '@/components/forms/Input'
+import RevisionHistoryTable from '@/components/forms/RevisionHistoryTable'
 import Select from '@/components/forms/Select'
+import { useTemplate } from '@/utils/template'
 import useDocumentStoreUpdater from '@/utils/useDocumentStoreUpdater'
+import usePageVisit from '@/utils/validation/usePageVisit'
 import { SelectItem } from '@heroui/select'
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { TDocumentInformation } from './types/tDocumentInformation'
 import {
+  TDocumentStatus,
   TGeneralDocumentInformation,
   getDefaultGeneralDocumentInformation,
 } from './types/tGeneralDocumentInformation'
-import { useTemplate } from '@/utils/template'
-import usePageVisit from '@/utils/validation/usePageVisit'
-import { useTranslation } from 'react-i18next'
-import RevisionHistoryTable from '@/components/forms/RevisionHistoryTable'
 
 export default function General() {
   const [localState, setLocalState] = useState<TGeneralDocumentInformation>(
@@ -37,16 +38,45 @@ export default function General() {
       progress={1}
       onContinue={'/document-information/notes'}
     >
-      <Input
-        label={t('document.general.title')}
-        csafPath="/document/title"
-        isTouched={hasVisitedPage}
-        value={localState.title}
-        onValueChange={(title) => setLocalState({ ...localState, title })}
-        isDisabled={isFieldReadonly('document-information.title')}
-        placeholder={getFieldPlaceholder('document-information.title')}
-        isRequired
-      />
+      <HSplit className="items-start">
+        <Input
+          label={t('document.general.title')}
+          csafPath="/document/title"
+          isTouched={hasVisitedPage}
+          value={localState.title}
+          onValueChange={(title) => setLocalState({ ...localState, title })}
+          isDisabled={isFieldReadonly('document-information.title')}
+          placeholder={getFieldPlaceholder('document-information.title')}
+          isRequired
+        />
+
+        <Select
+          className="w-1/2"
+          label={t('document.general.state')}
+          csafPath="/document/tracking/status"
+          isTouched={hasVisitedPage}
+          selectedKeys={[localState.status]}
+          onSelectionChange={(v) => {
+            if (!v.anchorKey) return
+
+            setLocalState({
+              ...localState,
+              status: [...v][0] as TDocumentStatus,
+            })
+          }}
+          isDisabled={isFieldReadonly('document-information.tracking.status')}
+          isRequired
+          placeholder={getFieldPlaceholder(
+            'document-information.tracking.status',
+          )}
+        >
+          {['draft', 'final', 'interim'].map((key) => (
+            <SelectItem key={key}>
+              {t(`document.general.status.${key}`)}
+            </SelectItem>
+          ))}
+        </Select>
+      </HSplit>
       <HSplit className="items-start">
         <Input
           label={t('document.general.id')}
@@ -59,6 +89,7 @@ export default function General() {
           isRequired
         />
         <Select
+          className="w-1/2"
           label={t('document.general.language')}
           csafPath="/document/lang"
           isTouched={hasVisitedPage}
@@ -71,7 +102,9 @@ export default function General() {
           placeholder={getFieldPlaceholder('document-information.language')}
         >
           {['de', 'en'].map((key) => (
-            <SelectItem key={key}>{key.toUpperCase()}</SelectItem>
+            <SelectItem key={key}>
+              {t(`document.general.languages.${key}`)}
+            </SelectItem>
           ))}
         </Select>
       </HSplit>

--- a/src/routes/document-information/types/tGeneralDocumentInformation.ts
+++ b/src/routes/document-information/types/tGeneralDocumentInformation.ts
@@ -4,13 +4,18 @@ export type TGeneralDocumentInformation = {
   title: string
   id: string
   language: string
+  status: TDocumentStatus
 }
+
+export const documentStatus = ['draft', 'final', 'interim'] as const
+export type TDocumentStatus = (typeof documentStatus)[number]
 
 export function getDefaultGeneralDocumentInformation(): TGeneralDocumentInformation {
   return {
     title: '',
     id: '',
-    language: '',
+    language: 'en', // Default to English
+    status: 'draft', // Default to draft status
   }
 }
 
@@ -19,5 +24,6 @@ export function getGeneralDocumentInformationTemplateKeys(): TemplateKeys<TGener
     title: 'document-information.title',
     id: 'document-information.id',
     language: 'document-information.language',
+    status: 'document-information.tracking.status',
   }
 }

--- a/src/utils/csafExport/csafExport.ts
+++ b/src/utils/csafExport/csafExport.ts
@@ -35,7 +35,7 @@ export function createCSAFDocument(documentStore: TDocumentStore) {
             summary: entry.summary,
           }),
         ),
-        status: 'final',
+        status: documentStore.documentInformation.status,
         version: documentStore.documentInformation.revisionHistory.length
           ? retrieveLatestVersion(
               documentStore.documentInformation.revisionHistory,

--- a/src/utils/csafImport/csafImport.ts
+++ b/src/utils/csafImport/csafImport.ts
@@ -46,6 +46,9 @@ export function parseCSAFDocument(
   const documentInformation: TDocumentInformation = {
     id: csafDoc?.tracking?.id || defaultDocumentInformation.id,
     language: csafDoc?.lang ?? defaultDocumentInformation.language,
+    status:
+      (csafDoc?.tracking?.status as TDocumentInformation['status']) ??
+      defaultDocumentInformation.status,
     title: csafDoc?.title ?? defaultDocumentInformation.title,
     revisionHistory:
       csafDoc?.tracking?.revision_history?.map((revision) => ({


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
The field document.tracking.status was missing and can now be edited.
More clear names for the language field was also added.

## Related Tickets & Documents

- Closes #69 
