### PR TITLE
feat: Product database import

### DIFF
--- a/.well-known/appspecific/io.github.sec-o-simple.json
+++ b/.well-known/appspecific/io.github.sec-o-simple.json
@@ -1,8 +1,0 @@
-{
-  "productDatabase": {
-    "enabled": true,
-    "apiUrl": "http://127.0.0.1:5000",
-    "url": "http://127.0.0.1:3000"
-  },
-  "template": {}
-}

--- a/.well-known/appspecific/io.github.sec-o-simple.json
+++ b/.well-known/appspecific/io.github.sec-o-simple.json
@@ -1,0 +1,8 @@
+{
+  "productDatabase": {
+    "enabled": true,
+    "apiUrl": "http://127.0.0.1:5000",
+    "url": "http://127.0.0.1:3000"
+  },
+  "template": {}
+}

--- a/docs/io.github.sec-o-simple.example.json
+++ b/docs/io.github.sec-o-simple.example.json
@@ -1,4 +1,9 @@
 {
+  "productDatabase": {
+    "enabled": false,
+    "apiUrl": "http://127.0.0.1:9999",
+    "url": "http://127.0.0.1:3000"
+  },
   "template": {
     "document-information.title": "Test Document",
     "document-information.title.readonly": true,

--- a/locales/de.json
+++ b/locales/de.json
@@ -21,18 +21,15 @@
       "placeholder": "{{label}} eingeben",
       "actions": "Aktionen"
     },
-
     "preview": "Vorschau",
     "newDocument": "Neues Dokument",
     "confirm.newDocument.title": "Neues Dokument erstellen",
     "confirm.newDocument.body": "Sind Sie sicher, dass Sie ein neues Dokument erstellen möchten? Dadurch wird das aktuelle Dokument zurückgesetzt.",
-
     "export": {
       "draft": "Export",
       "csaf": "CSAF Export",
       "error": "{{ errorCount }} Fehler im Dokument. Bitte beheben Sie diese vor dem Export"
     },
-
     "nav": {
       "home": "Startseite",
       "products": "Produkte",
@@ -47,7 +44,6 @@
         "references": "Referenzen"
       }
     },
-
     "documentSelection": {
       "create": "Dokument erstellen",
       "selectType": "Dokumenttyp auswählen",
@@ -61,7 +57,6 @@
       "softAndFirmware": "Software und Firmware",
       "sbom": "SBOM"
     },
-
     "document": {
       "general": {
         "title": "Dokumenttitel",
@@ -104,7 +99,6 @@
         "url": "URL"
       }
     },
-
     "vulnerabilities": {
       "vulnerability": "Schwachstelle",
       "vulnerabilities": "Schwachstellen",
@@ -138,7 +132,6 @@
         "products.empty": "Keine Produkte hinzugefügt"
       }
     },
-
     "notes": {
       "title": "Notiz Titel",
       "note": "Notiz",
@@ -156,7 +149,6 @@
         "summary": "Zusammenfassung"
       }
     },
-
     "ref": {
       "references": "Referenzen",
       "reference": "Referenz",
@@ -168,18 +160,15 @@
         "self": "Intern"
       }
     },
-
     "untitled": {
       "vendor": "Unbenannter Anbieter",
       "product_name": "Unbenanntes Produkt",
       "product_version": "Unbenannte Produktversion",
       "": "Unbenannt"
     },
-
     "modal": {
       "edit": "{{label}} bearbeiten"
     },
-
     "vendor": {
       "label": "Anbieter",
       "name": "Anbietername",
@@ -196,54 +185,56 @@
       "description": "Produktbeschreibung",
       "type": "Produktart"
     },
-
     "products": {
+      "import": {
+        "title": "Aus Datenbank hinzufügen",
+        "description": "Wähle ein oder mehrere Produkte aus deiner bestehenden Produktdatenbank aus, um sie zu deinem Dokument hinzuzufügen.",
+        "database": "Datenbank",
+        "warning": "Änderungen an den hinzugefügten Produkten werden nicht gespeichert. Um Produkte zu bearbeiten, hinzuzufügen oder zu löschen, besuche bitte die",
+        "noVendors": "Keine Anbieter in der Datenbank gefunden. Bitte füge Anbieter und Produkte zur Datenbank hinzu, bevor du diese Funktion verwendest.",
+        "searchPlaceholder": "Anbieter und Produkte suchen",
+        "selectedAll": "Alle Produkte ausgewählt",
+        "selected_one": "1 Produkt ausgewählt",
+        "selected_other": "{{count}} Produkte ausgewählt",
+        "add_one": "1 Produkt hinzufügen",
+        "add_other": "{{count}} Produkte hinzufügen"
+      },
       "vendors": "Anbieter",
       "products": "Produkte",
       "manage": "Produktverwaltung",
-
       "empty": "Sie haben noch kein {{ type }}-Produkt erstellt.\nSie können eines hinzufügen, indem Sie einen Anbieter erstellen und ihm ein Produkt hinzufügen.",
-
       "software": "Software",
       "hardware": "Hardware",
-
       "vendor": {
         "label": "Anbieter"
       },
-
       "product": {
         "label": "Produkt",
         "name": "Produktname",
         "description": "Produktbeschreibung",
         "type": "Produktart",
-
         "version": {
           "label": "Version",
           "empty": "Keine Versionen vorhanden",
           "edit": "Produktversion bearbeiten",
           "edit_plural": "Produktversionen bearbeiten",
-
           "affected": "Betroffene Versionen",
           "fixed": "Reparierte Versionen"
         }
       },
-
       "relationship": {
         "label": "Beziehungen",
         "empty": "Keine Beziehungen vorhanden",
         "edit": "Beziehung bearbeiten",
         "edit_plural": "Beziehungen bearbeiten",
-
         "name": "Name",
         "namePlaceholder": "Beziehungsname",
         "sourceProduct": "Quelle",
         "targetProduct": "Ziel",
         "version": "Version",
         "version_plural": "Versionen",
-
         "category": "Beziehungstyp",
         "categoryPlaceholder": "Beziehungstyp auswählen",
-
         "categories": {
           "default_component_of": "Standardkomponente von",
           "external_component_of": "Externe Komponente von",
@@ -253,7 +244,6 @@
         }
       }
     },
-
     "validation": {
       "error": "Fehler",
       "error_plural": "Fehler",

--- a/locales/en.json
+++ b/locales/en.json
@@ -44,14 +44,12 @@
         "references": "References"
       }
     },
-
     "documentSelection": {
       "create": "Create document",
       "selectType": "Select Document Type",
       "selectTypeDescription": "Choose whether you want to create a new document or edit an existing one",
       "newDocument": "Create new Document",
       "existingDocument": "Edit existing Document",
-
       "advisory": "Security Advisory",
       "vex": "VEX Document",
       "software": "Software",
@@ -59,7 +57,6 @@
       "softAndFirmware": "Software and Firmware",
       "sbom": "SBOM"
     },
-
     "document": {
       "general": {
         "title": "Document Title",
@@ -189,6 +186,19 @@
       "type": "Product Type"
     },
     "products": {
+      "import": {
+        "title": "Add from Database",
+        "description": "Choose one or more products from your existing product database to add to your document.",
+        "database": "database",
+        "warning": "Changes to the added products will not be persisted. To modify, add, or delete products, please visit the",
+        "noVendors": "No vendors found in the database. Please add vendors and products to the database before using this feature.",
+        "searchPlaceholder": "Search vendors and products",
+        "selectedAll": "selected all products",
+        "selected_one": "selected 1 product",
+        "selected_other": "selected {{count}} products",
+        "add_one": "Add 1 product",
+        "add_other": "Add {{count}} products"
+      },
       "vendors": "Vendors",
       "products": "Products",
       "manage": "Product Management",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@heroui/theme": "^2.4.9",
         "@internationalized/date": "3.8.0",
         "@secvisogram/csaf-validator-lib": "^1.3.50",
+        "axios": "^1.10.0",
         "cvss4": "^1.0.7",
         "i18next": "^25.2.1",
         "motion": "^12.4.7",
@@ -5834,7 +5835,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -5912,6 +5912,23 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
     "node_modules/balanced-match": {
@@ -6110,7 +6127,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6397,7 +6413,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -6738,7 +6753,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -6786,7 +6800,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -6921,7 +6934,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6931,7 +6943,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6969,7 +6980,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -6982,7 +6992,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7803,6 +7812,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -7867,7 +7896,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
       "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -8001,7 +8029,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -8026,7 +8053,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -8198,7 +8224,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8277,7 +8302,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8290,7 +8314,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -9367,7 +9390,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9406,7 +9428,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -9416,7 +9437,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@heroui/theme": "^2.4.9",
     "@internationalized/date": "3.8.0",
     "@secvisogram/csaf-validator-lib": "^1.3.50",
+    "axios": "^1.10.0",
     "cvss4": "^1.0.7",
     "i18next": "^25.2.1",
     "motion": "^12.4.7",

--- a/src/routes/products/ProductManagement.tsx
+++ b/src/routes/products/ProductManagement.tsx
@@ -24,7 +24,10 @@ export default function ProductManagement() {
       onContinue={'/vulnerabilities'}
       noContentWrapper
     >
-      <ProductDatabaseSelector isOpen={modalOpen} onClose={() => setModalOpen(false)} />
+      <ProductDatabaseSelector
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+      />
       <div className="flex w-full items-center justify-between rounded-lg border-1 border-default-200 bg-white p-8">
         <p className="text-xl font-semibold">{t('products.manage')}</p>
 

--- a/src/routes/products/ProductManagement.tsx
+++ b/src/routes/products/ProductManagement.tsx
@@ -19,6 +19,8 @@ export default function ProductManagement() {
   const [modalOpen, setModalOpen] = useState(false)
   const config = useConfigStore((state) => state.config)
 
+  const productDbEnabled = config?.productDatabase?.enabled && config?.productDatabase?.url
+
   return (
     <WizardStep
       progress={2}
@@ -26,14 +28,15 @@ export default function ProductManagement() {
       onContinue={'/vulnerabilities'}
       noContentWrapper
     >
+      {productDbEnabled && (
       <ProductDatabaseSelector
         isOpen={modalOpen}
         onClose={() => setModalOpen(false)}
-      />
+      />)}
       <div className="flex w-full items-center justify-between rounded-lg border-1 border-default-200 bg-white p-8">
         <p className="text-xl font-semibold">{t('products.manage')}</p>
 
-        {config?.productDatabase.enabled && config?.productDatabase.url && (
+        {productDbEnabled && (
           <Button
             variant="solid"
             color="primary"

--- a/src/routes/products/ProductManagement.tsx
+++ b/src/routes/products/ProductManagement.tsx
@@ -44,7 +44,7 @@ export default function ProductManagement() {
             color="primary"
             onPress={() => setModalOpen(true)}
           >
-            Add from Database
+            {t('products.import.title')}
           </Button>
         )}
       </div>

--- a/src/routes/products/ProductManagement.tsx
+++ b/src/routes/products/ProductManagement.tsx
@@ -19,7 +19,8 @@ export default function ProductManagement() {
   const [modalOpen, setModalOpen] = useState(false)
   const config = useConfigStore((state) => state.config)
 
-  const productDbEnabled = config?.productDatabase?.enabled && config?.productDatabase?.url
+  const productDbEnabled =
+    config?.productDatabase?.enabled && config?.productDatabase?.url
 
   return (
     <WizardStep
@@ -29,10 +30,11 @@ export default function ProductManagement() {
       noContentWrapper
     >
       {productDbEnabled && (
-      <ProductDatabaseSelector
-        isOpen={modalOpen}
-        onClose={() => setModalOpen(false)}
-      />)}
+        <ProductDatabaseSelector
+          isOpen={modalOpen}
+          onClose={() => setModalOpen(false)}
+        />
+      )}
       <div className="flex w-full items-center justify-between rounded-lg border-1 border-default-200 bg-white p-8">
         <p className="text-xl font-semibold">{t('products.manage')}</p>
 

--- a/src/routes/products/ProductManagement.tsx
+++ b/src/routes/products/ProductManagement.tsx
@@ -6,12 +6,16 @@ import useDocumentStore from '@/utils/useDocumentStore'
 import ProductList from './ProductList'
 import { useTranslation } from 'react-i18next'
 import usePageVisit from '@/utils/validation/usePageVisit'
+import ProductDatabaseSelector from './components/ProductDatabaseSelector'
+import { Button } from '@heroui/button'
 
 export default function ProductManagement() {
   usePageVisit()
   const { t } = useTranslation()
+
   const [selectedTab, setSelectedTab] = useState<string>('Vendors')
   const sosDocumentType = useDocumentStore((state) => state.sosDocumentType)
+  const [modalOpen, setModalOpen] = useState(false)
 
   return (
     <WizardStep
@@ -20,8 +24,17 @@ export default function ProductManagement() {
       onContinue={'/vulnerabilities'}
       noContentWrapper
     >
+      <ProductDatabaseSelector isOpen={modalOpen} onClose={() => setModalOpen(false)} />
       <div className="flex w-full items-center justify-between rounded-lg border-1 border-default-200 bg-white p-8">
         <p className="text-xl font-semibold">{t('products.manage')}</p>
+
+        <Button
+          variant="solid"
+          color="primary"
+          onPress={() => setModalOpen(true)}
+        >
+          Add from Database
+        </Button>
       </div>
 
       <div className="px-6">

--- a/src/routes/products/ProductManagement.tsx
+++ b/src/routes/products/ProductManagement.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next'
 import usePageVisit from '@/utils/validation/usePageVisit'
 import ProductDatabaseSelector from './components/ProductDatabaseSelector'
 import { Button } from '@heroui/button'
+import { useConfigStore } from '@/utils/useConfigStore'
 
 export default function ProductManagement() {
   usePageVisit()
@@ -16,6 +17,7 @@ export default function ProductManagement() {
   const [selectedTab, setSelectedTab] = useState<string>('Vendors')
   const sosDocumentType = useDocumentStore((state) => state.sosDocumentType)
   const [modalOpen, setModalOpen] = useState(false)
+  const config = useConfigStore((state) => state.config)
 
   return (
     <WizardStep
@@ -31,13 +33,15 @@ export default function ProductManagement() {
       <div className="flex w-full items-center justify-between rounded-lg border-1 border-default-200 bg-white p-8">
         <p className="text-xl font-semibold">{t('products.manage')}</p>
 
-        <Button
-          variant="solid"
-          color="primary"
-          onPress={() => setModalOpen(true)}
-        >
-          Add from Database
-        </Button>
+        {config?.productDatabase.enabled && config?.productDatabase.url && (
+          <Button
+            variant="solid"
+            color="primary"
+            onPress={() => setModalOpen(true)}
+          >
+            Add from Database
+          </Button>
+        )}
       </div>
 
       <div className="px-6">

--- a/src/routes/products/components/ProductDatabaseSelector.tsx
+++ b/src/routes/products/components/ProductDatabaseSelector.tsx
@@ -36,7 +36,7 @@ export default function ProductDatabaseSelector({ isOpen, onClose }: Props) {
   const config = useConfigStore((state) => state.config)
   const products = Object.values(useDocumentStore((store) => store.products))
   const updateProducts = useDocumentStore((store) => store.updateProducts)
-  
+
   const { t } = useTranslation()
   const [selectedProducts, setSelectedProducts] = useState<string[]>([])
   const [vendors, setVendors] = useState<Vendor[]>([])
@@ -83,7 +83,6 @@ export default function ProductDatabaseSelector({ isOpen, onClose }: Props) {
 
     setSubmitting(true)
 
-    
     try {
       let updatedProducts: TProductTreeBranch[] = products.slice()
 
@@ -173,12 +172,11 @@ export default function ProductDatabaseSelector({ isOpen, onClose }: Props) {
               {t('products.import.title')}
             </ModalHeader>
             <ModalBody>
-              <p>
-                {t('products.import.description')}
-              </p>
+              <p>{t('products.import.description')}</p>
               <Alert className="mt-2" color="default">
                 <p>
-                  {t('products.import.warning')} <Link
+                  {t('products.import.warning')}{' '}
+                  <Link
                     to={config?.productDatabase?.url || '#'}
                     className="underline"
                     target="_blank"
@@ -226,7 +224,9 @@ export default function ProductDatabaseSelector({ isOpen, onClose }: Props) {
                           selectedProductCount
                             ? selectedAllProducts
                               ? t('products.import.selectedAll')
-                              : t('products.import.selected', { count: selectedProductCount })
+                              : t('products.import.selected', {
+                                  count: selectedProductCount,
+                                })
                             : ''
                         }
                         startContent={

--- a/src/routes/products/components/ProductDatabaseSelector.tsx
+++ b/src/routes/products/components/ProductDatabaseSelector.tsx
@@ -1,50 +1,56 @@
-import { Input } from "@/components/forms/Input";
-import { faSearch } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Button } from "@heroui/button";
-import { Modal, ModalContent, ModalHeader, ModalBody, ModalFooter } from "@heroui/modal";
-import { Accordion, AccordionItem, Alert, Checkbox } from "@heroui/react";
-import { useState } from "react";
-import { Link } from "react-router";
+import { Input } from '@/components/forms/Input'
+import { faSearch } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { Button } from '@heroui/button'
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+} from '@heroui/modal'
+import { Accordion, AccordionItem, Alert, Checkbox } from '@heroui/react'
+import { useState } from 'react'
+import { Link } from 'react-router'
 
 interface Props {
-  isOpen: boolean;
-  onClose: () => void;
+  isOpen: boolean
+  onClose: () => void
 }
 
 interface Product {
-  id: string;
-  name: string;
+  id: string
+  name: string
 }
 
 interface Vendor {
-  id: string;
-  name: string;
-  products: Product[];
+  id: string
+  name: string
+  products: Product[]
 }
 
 export default function ProductDatabaseSelector({ isOpen, onClose }: Props) {
-  const vendors = [
+  const vendors: Vendor[] = [
     {
-      id: "vendor1",
-      name: "Vendor 1",
+      id: 'vendor1',
+      name: 'Vendor 1',
       products: [
-        { id: "product1", name: "Product A" },
-        { id: "product2", name: "Product B" },
+        { id: 'product1', name: 'Product A' },
+        { id: 'product2', name: 'Product B' },
       ],
     },
     {
-      id: "vendor2",
-      name: "Vendor 2",
+      id: 'vendor2',
+      name: 'Vendor 2',
       products: [
-        { id: "product3", name: "Product C" },
-        { id: "product4", name: "Product D" },
-        { id: "product5", name: "Product E" },
+        { id: 'product3', name: 'Product C' },
+        { id: 'product4', name: 'Product D' },
+        { id: 'product5', name: 'Product E' },
       ],
-    }
-  ];
+    },
+  ]
 
-  const [selectedProducts, setSelectedProducts] = useState<string[]>([]);
+  const [selectedProducts, setSelectedProducts] = useState<string[]>([])
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="lg">
@@ -56,13 +62,22 @@ export default function ProductDatabaseSelector({ isOpen, onClose }: Props) {
             </ModalHeader>
             <ModalBody>
               <p>
-                Choose one or more products from your existing product database to add to your document.
+                Choose one or more products from your existing product database
+                to add to your document.
               </p>
-              <Alert
-                className="mt-2"
-                color="default"
-              >
-                <p>Changes to the added products will not be persisted. To modify, add, or delete products, please visit the <Link to="http://localhost:3000" className="underline" target="_blank">database</Link>.</p>
+              <Alert className="mt-2" color="default">
+                <p>
+                  Changes to the added products will not be persisted. To
+                  modify, add, or delete products, please visit the{' '}
+                  <Link
+                    to="http://localhost:3000"
+                    className="underline"
+                    target="_blank"
+                  >
+                    database
+                  </Link>
+                  .
+                </p>
               </Alert>
               <div className="py-4">
                 <Input
@@ -78,37 +93,58 @@ export default function ProductDatabaseSelector({ isOpen, onClose }: Props) {
 
                 <Accordion variant="shadow">
                   {vendors.map((vendor) => {
-                    const vendorProducts = vendor.products.map(product => product.id);
-                    const selectedProductCount = selectedProducts.filter(id => vendorProducts.includes(id)).length;
-                    const selectedAllProducts = selectedProductCount === vendor.products.length;
+                    const vendorProducts = vendor.products.map(
+                      (product) => product.id,
+                    )
+                    const selectedProductCount = selectedProducts.filter((id) =>
+                      vendorProducts.includes(id),
+                    ).length
+                    const selectedAllProducts =
+                      selectedProductCount === vendor.products.length
 
                     return (
                       <AccordionItem
                         key={vendor.id}
                         title={vendor.name}
-                        subtitle={selectedProductCount ? (selectedAllProducts ? 'selected all products' : 'selected ' + selectedProductCount + ' product' + (selectedProductCount !== 1 ? 's' : '')) : ''}
-                        startContent={<Checkbox isSelected={selectedAllProducts} onChange={() => {
-                          setSelectedProducts((prev) => {
-                            if (selectedAllProducts) {
-                              return prev.filter(id => !vendorProducts.includes(id));
-                            } else {
-                              return [...prev, ...vendorProducts];
-                            }
-                          });
-                        }} />}
+                        subtitle={
+                          selectedProductCount
+                            ? selectedAllProducts
+                              ? 'selected all products'
+                              : 'selected ' +
+                                selectedProductCount +
+                                ' product' +
+                                (selectedProductCount !== 1 ? 's' : '')
+                            : ''
+                        }
+                        startContent={
+                          <Checkbox
+                            isSelected={selectedAllProducts}
+                            onChange={() => {
+                              setSelectedProducts((prev) => {
+                                if (selectedAllProducts) {
+                                  return prev.filter(
+                                    (id) => !vendorProducts.includes(id),
+                                  )
+                                } else {
+                                  return [...prev, ...vendorProducts]
+                                }
+                              })
+                            }}
+                          />
+                        }
                       >
-                        <div className="ml-4 pb-4 flex flex-col gap-2">
+                        <div className="ml-4 flex flex-col gap-2 pb-4">
                           {vendor.products.map((product) => (
                             <Checkbox
                               key={product.id}
                               isSelected={selectedProducts.includes(product.id)}
                               onChange={(e) => {
-                                const isChecked = e.target.checked;
+                                const isChecked = e.target.checked
                                 setSelectedProducts((prev) =>
                                   isChecked
                                     ? [...prev, product.id]
-                                    : prev.filter((id) => id !== product.id)
-                                );
+                                    : prev.filter((id) => id !== product.id),
+                                )
                               }}
                             >
                               {product.name}
@@ -125,8 +161,13 @@ export default function ProductDatabaseSelector({ isOpen, onClose }: Props) {
               <Button color="danger" variant="light" onPress={onClose}>
                 Cancel
               </Button>
-              <Button color="primary" onPress={onClose} isDisabled={selectedProducts.length === 0}>
-                Add {selectedProducts.length} Product{selectedProducts.length !== 1 ? 's' : ''}
+              <Button
+                color="primary"
+                onPress={onClose}
+                isDisabled={selectedProducts.length === 0}
+              >
+                Add {selectedProducts.length} Product
+                {selectedProducts.length !== 1 ? 's' : ''}
               </Button>
             </ModalFooter>
           </>

--- a/src/routes/products/components/ProductDatabaseSelector.tsx
+++ b/src/routes/products/components/ProductDatabaseSelector.tsx
@@ -1,4 +1,5 @@
 import { Input } from '@/components/forms/Input'
+import { useConfigStore } from '@/utils/useConfigStore'
 import { faSearch } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button } from '@heroui/button'
@@ -30,6 +31,8 @@ interface Vendor {
 }
 
 export default function ProductDatabaseSelector({ isOpen, onClose }: Props) {
+  const config = useConfigStore((state) => state.config)
+
   const vendors: Vendor[] = [
     {
       id: 'vendor1',
@@ -70,7 +73,7 @@ export default function ProductDatabaseSelector({ isOpen, onClose }: Props) {
                   Changes to the added products will not be persisted. To
                   modify, add, or delete products, please visit the{' '}
                   <Link
-                    to="http://localhost:3000"
+                    to={config?.productDatabase.url || '#'}
                     className="underline"
                     target="_blank"
                   >

--- a/src/routes/products/components/ProductDatabaseSelector.tsx
+++ b/src/routes/products/components/ProductDatabaseSelector.tsx
@@ -1,0 +1,137 @@
+import { Input } from "@/components/forms/Input";
+import { faSearch } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Button } from "@heroui/button";
+import { Modal, ModalContent, ModalHeader, ModalBody, ModalFooter } from "@heroui/modal";
+import { Accordion, AccordionItem, Alert, Checkbox } from "@heroui/react";
+import { useState } from "react";
+import { Link } from "react-router";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface Product {
+  id: string;
+  name: string;
+}
+
+interface Vendor {
+  id: string;
+  name: string;
+  products: Product[];
+}
+
+export default function ProductDatabaseSelector({ isOpen, onClose }: Props) {
+  const vendors = [
+    {
+      id: "vendor1",
+      name: "Vendor 1",
+      products: [
+        { id: "product1", name: "Product A" },
+        { id: "product2", name: "Product B" },
+      ],
+    },
+    {
+      id: "vendor2",
+      name: "Vendor 2",
+      products: [
+        { id: "product3", name: "Product C" },
+        { id: "product4", name: "Product D" },
+        { id: "product5", name: "Product E" },
+      ],
+    }
+  ];
+
+  const [selectedProducts, setSelectedProducts] = useState<string[]>([]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="lg">
+      <ModalContent>
+        {(onClose) => (
+          <>
+            <ModalHeader className="flex flex-col gap-1">
+              Add from Database
+            </ModalHeader>
+            <ModalBody>
+              <p>
+                Choose one or more products from your existing product database to add to your document.
+              </p>
+              <Alert
+                className="mt-2"
+                color="default"
+              >
+                <p>Changes to the added products will not be persisted. To modify, add, or delete products, please visit the <Link to="http://localhost:3000" className="underline" target="_blank">database</Link>.</p>
+              </Alert>
+              <div className="py-4">
+                <Input
+                  placeholder="Search vendors and products"
+                  className="mb-2"
+                  startContent={
+                    <FontAwesomeIcon
+                      icon={faSearch}
+                      className="text-neutral-foreground"
+                    />
+                  }
+                />
+
+                <Accordion variant="shadow">
+                  {vendors.map((vendor) => {
+                    const vendorProducts = vendor.products.map(product => product.id);
+                    const selectedProductCount = selectedProducts.filter(id => vendorProducts.includes(id)).length;
+                    const selectedAllProducts = selectedProductCount === vendor.products.length;
+
+                    return (
+                      <AccordionItem
+                        key={vendor.id}
+                        title={vendor.name}
+                        subtitle={selectedProductCount ? (selectedAllProducts ? 'selected all products' : 'selected ' + selectedProductCount + ' product' + (selectedProductCount !== 1 ? 's' : '')) : ''}
+                        startContent={<Checkbox isSelected={selectedAllProducts} onChange={() => {
+                          setSelectedProducts((prev) => {
+                            if (selectedAllProducts) {
+                              return prev.filter(id => !vendorProducts.includes(id));
+                            } else {
+                              return [...prev, ...vendorProducts];
+                            }
+                          });
+                        }} />}
+                      >
+                        <div className="ml-4 pb-4 flex flex-col gap-2">
+                          {vendor.products.map((product) => (
+                            <Checkbox
+                              key={product.id}
+                              isSelected={selectedProducts.includes(product.id)}
+                              onChange={(e) => {
+                                const isChecked = e.target.checked;
+                                setSelectedProducts((prev) =>
+                                  isChecked
+                                    ? [...prev, product.id]
+                                    : prev.filter((id) => id !== product.id)
+                                );
+                              }}
+                            >
+                              {product.name}
+                            </Checkbox>
+                          ))}
+                        </div>
+                      </AccordionItem>
+                    )
+                  })}
+                </Accordion>
+              </div>
+            </ModalBody>
+            <ModalFooter>
+              <Button color="danger" variant="light" onPress={onClose}>
+                Cancel
+              </Button>
+              <Button color="primary" onPress={onClose} isDisabled={selectedProducts.length === 0}>
+                Add {selectedProducts.length} Product{selectedProducts.length !== 1 ? 's' : ''}
+              </Button>
+            </ModalFooter>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/utils/useConfigStore.ts
+++ b/src/utils/useConfigStore.ts
@@ -7,7 +7,7 @@ const DEFAULT_CONFIG: TConfig = {
   template: {},
   productDatabase: {
     enabled: false,
-  }
+  },
 }
 
 export type TConfig = {
@@ -15,7 +15,7 @@ export type TConfig = {
     enabled: boolean
     url?: string
     apiUrl?: string
-  },
+  }
   template: { [key: string]: unknown }
 }
 

--- a/src/utils/useConfigStore.ts
+++ b/src/utils/useConfigStore.ts
@@ -14,6 +14,7 @@ export type TConfig = {
   productDatabase: {
     enabled: boolean
     url?: string
+    apiUrl?: string
   },
   template: { [key: string]: unknown }
 }

--- a/src/utils/useConfigStore.ts
+++ b/src/utils/useConfigStore.ts
@@ -5,9 +5,16 @@ const CONFIG_NAME = 'io.github.sec-o-simple.json'
 
 const DEFAULT_CONFIG: TConfig = {
   template: {},
+  productDatabase: {
+    enabled: false,
+  }
 }
 
 export type TConfig = {
+  productDatabase: {
+    enabled: boolean
+    url?: string
+  },
   template: { [key: string]: unknown }
 }
 

--- a/src/utils/useDatabaseClient.ts
+++ b/src/utils/useDatabaseClient.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect } from "react";
+import { useConfigStore } from "./useConfigStore";
+import axios from "axios";
+
+export interface Vendor {
+  id: string;
+  name: string;
+  description: string;
+  product_count: number;
+}
+
+export interface Product {
+  vendor_id: string;
+  type: string;
+  id: string;
+  name: string;
+  full_name: string;
+  description: string;
+}
+
+export interface ProductVersion {
+  id: string;
+  name: string;
+  description: string;
+}
+
+const client = axios.create({
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export function useDatabaseClient() {
+  const config = useConfigStore((state) => state.config);
+
+  if (!config?.productDatabase?.enabled || !config?.productDatabase?.apiUrl) {
+    throw new Error("Product database is not enabled in the configuration.");
+  }
+
+  const apiUrl = `${config.productDatabase.apiUrl}/api/v1`;
+
+  useEffect(() => {
+    client.defaults.baseURL = apiUrl;
+  }, [apiUrl]);
+
+  const fetchVendors = useCallback(async (): Promise<Vendor[]> => {
+    const response = await client.get<Vendor[]>('/vendors');
+    return response.data;
+  }, []);
+
+  const fetchProducts = useCallback(async (): Promise<Product[]> => {
+    const response = await client.get<Product[]>('/products');
+    return response.data;
+  }, []);
+
+  const fetchProductVersions = useCallback(async (productId: string): Promise<ProductVersion[]> => {
+    const response = await client.get<ProductVersion[]>(`/products/${productId}/versions`);
+    return response.data;
+  }, []);
+
+  return {
+    url: config.productDatabase.url,
+    fetchVendors,
+    fetchProducts,
+    fetchProductVersions,
+  }
+}

--- a/src/utils/useDatabaseClient.ts
+++ b/src/utils/useDatabaseClient.ts
@@ -1,62 +1,67 @@
-import { useCallback, useEffect } from "react";
-import { useConfigStore } from "./useConfigStore";
-import axios from "axios";
+import { useCallback, useEffect } from 'react'
+import { useConfigStore } from './useConfigStore'
+import axios from 'axios'
 
 export interface Vendor {
-  id: string;
-  name: string;
-  description: string;
-  product_count: number;
+  id: string
+  name: string
+  description: string
+  product_count: number
 }
 
 export interface Product {
-  vendor_id: string;
-  type: string;
-  id: string;
-  name: string;
-  full_name: string;
-  description: string;
+  vendor_id: string
+  type: string
+  id: string
+  name: string
+  full_name: string
+  description: string
 }
 
 export interface ProductVersion {
-  id: string;
-  name: string;
-  description: string;
+  id: string
+  name: string
+  description: string
 }
 
 const client = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-});
+})
 
 export function useDatabaseClient() {
-  const config = useConfigStore((state) => state.config);
+  const config = useConfigStore((state) => state.config)
 
   if (!config?.productDatabase?.enabled || !config?.productDatabase?.apiUrl) {
-    throw new Error("Product database is not enabled in the configuration.");
+    throw new Error('Product database is not enabled in the configuration.')
   }
 
-  const apiUrl = `${config.productDatabase.apiUrl}/api/v1`;
+  const apiUrl = `${config.productDatabase.apiUrl}/api/v1`
 
   useEffect(() => {
-    client.defaults.baseURL = apiUrl;
-  }, [apiUrl]);
+    client.defaults.baseURL = apiUrl
+  }, [apiUrl])
 
   const fetchVendors = useCallback(async (): Promise<Vendor[]> => {
-    const response = await client.get<Vendor[]>('/vendors');
-    return response.data;
-  }, []);
+    const response = await client.get<Vendor[]>('/vendors')
+    return response.data
+  }, [])
 
   const fetchProducts = useCallback(async (): Promise<Product[]> => {
-    const response = await client.get<Product[]>('/products');
-    return response.data;
-  }, []);
+    const response = await client.get<Product[]>('/products')
+    return response.data
+  }, [])
 
-  const fetchProductVersions = useCallback(async (productId: string): Promise<ProductVersion[]> => {
-    const response = await client.get<ProductVersion[]>(`/products/${productId}/versions`);
-    return response.data;
-  }, []);
+  const fetchProductVersions = useCallback(
+    async (productId: string): Promise<ProductVersion[]> => {
+      const response = await client.get<ProductVersion[]>(
+        `/products/${productId}/versions`,
+      )
+      return response.data
+    },
+    [],
+  )
 
   return {
     url: config.productDatabase.url,


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
Implements the functionality that users can import vendors, products and their versions from their product database which is configured using the `io.github.sec-o-simple.json` file. By default, it is disabled.

## Screenshots
<img width="581" alt="image" src="https://github.com/user-attachments/assets/1c6552ef-4217-4dfb-92f8-45588ecee494" />

## Future Work
Additionally import relationships and properly deal with a large amount of vendors/products/versions. The search functionality could also be enhanced, a refresh button and perhaps only showing software products when set as the category.

## Related Tickets & Documents
- Closes #59 and #58 
