### PR TITLE
use revision history for the csaf export

### DIFF
--- a/src/utils/csafExport/csafExport.ts
+++ b/src/utils/csafExport/csafExport.ts
@@ -15,6 +15,7 @@ export function createCSAFDocument(documentStore: TDocumentStore) {
   const pidGenerator = new PidGenerator()
   const currentDate = new Date().toISOString()
   const documentInformation = documentStore.documentInformation
+  const revisionHistory = documentInformation.revisionHistory || []
 
   const csafDocument = {
     document: {
@@ -28,8 +29,9 @@ export function createCSAFDocument(documentStore: TDocumentStore) {
             name: 'Sec-O-Simple',
           },
         },
-        current_release_date: currentDate,
-        initial_release_date: currentDate,
+        current_release_date:
+          revisionHistory[revisionHistory.length - 1]?.date || currentDate,
+        initial_release_date: revisionHistory[0]?.date || currentDate,
         revision_history: documentStore.documentInformation.revisionHistory.map(
           (entry) => ({
             date: entry.date,

--- a/src/utils/csafExport/csafExport.ts
+++ b/src/utils/csafExport/csafExport.ts
@@ -32,13 +32,11 @@ export function createCSAFDocument(documentStore: TDocumentStore) {
         current_release_date:
           revisionHistory[revisionHistory.length - 1]?.date || currentDate,
         initial_release_date: revisionHistory[0]?.date || currentDate,
-        revision_history: documentStore.documentInformation.revisionHistory.map(
-          (entry) => ({
-            date: entry.date,
-            number: entry.number,
-            summary: entry.summary,
-          }),
-        ),
+        revision_history: revisionHistory.map((entry) => ({
+          date: entry.date,
+          number: entry.number,
+          summary: entry.summary,
+        })),
         status: documentStore.documentInformation.status,
         version: documentStore.documentInformation.revisionHistory.length
           ? retrieveLatestVersion(


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
For the initial and current release date the first and last entry of the Revision History is used as the date.

## Related Tickets & Documents

- Closes #70 
- Closes #71 
