### PR TITLE
enhancement: Move revision history and status into its own step

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -63,7 +63,7 @@
       "general": {
         "title": "Dokumenttitel",
         "id": "Dokument-ID",
-        "state": "Status",
+        "state": "Dokumentstatus",
         "language": "Sprache",
         "languages": {
           "de": "Deutsch",
@@ -75,6 +75,7 @@
           "interim": "Zwischenstand"
         },
         "revisionHistory": {
+          "history": "Revisionsverlauf",
           "label": "Revision",
           "version": "Version",
           "date": "Datum",

--- a/locales/de.json
+++ b/locales/de.json
@@ -43,7 +43,8 @@
         "publisher": "Herausgeber",
         "references": "Referenzen",
         "acknowledgments": "Danksagungen"
-      }
+      },
+      "tracking": "Historie"
     },
     "documentSelection": {
       "create": "Dokument erstellen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -43,7 +43,8 @@
         "publisher": "Publisher",
         "references": "References",
         "acknowledgments": "Acknowledgements"
-      }
+      },
+      "tracking": "History"
     },
     "documentSelection": {
       "create": "Create document",

--- a/locales/en.json
+++ b/locales/en.json
@@ -63,7 +63,7 @@
       "general": {
         "title": "Document Title",
         "id": "Document ID",
-        "state": "Status",
+        "state": "Document Status",
         "language": "Language",
         "languages": {
           "de": "German",
@@ -75,6 +75,7 @@
           "interim": "Interim"
         },
         "revisionHistory": {
+          "history": "Revision History",
           "label": "Revision",
           "version": "Version",
           "date": "Date",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import ProductManagement from './routes/products/ProductManagement'
 import Product from './routes/products/Product'
 import Version from './routes/products/Version'
 import Acknowledgments from './routes/document-information/Acknowledgments'
+import Tracking from './routes/document-information/Tracking'
 
 export default function App() {
   useConfigInitializer()
@@ -38,6 +39,7 @@ export default function App() {
               <Route path="version/:productVersionId" element={<Version />} />
             </Route>
             <Route path="vulnerabilities" element={<Vulnerabilities />} />
+            <Route path="tracking" element={<Tracking />} />
           </Route>
         </Route>
       </Routes>

--- a/src/components/WizardStep.tsx
+++ b/src/components/WizardStep.tsx
@@ -30,6 +30,7 @@ export default function WizardStep({
           t('nav.document'),
           t('nav.products'),
           t('nav.vulnerabilities'),
+          t('nav.tracking'),
         ]}
         progress={progress ?? 1}
       />

--- a/src/components/forms/RevisionHistoryTable.tsx
+++ b/src/components/forms/RevisionHistoryTable.tsx
@@ -80,7 +80,9 @@ export default function RevisionHistoryTable() {
   return (
     <div className="mt-4">
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-lg font-semibold">Revision History</h2>
+        <h2 className="text-lg font-semibold">
+          {t('document.general.revisionHistory.history')}
+        </h2>
         <Button variant="light" color="primary" onPress={handleAddRevision}>
           {t('common.add', {
             label: t('document.general.revisionHistory.label'),

--- a/src/components/layout/NavigationLayout.tsx
+++ b/src/components/layout/NavigationLayout.tsx
@@ -50,11 +50,7 @@ export default function NavigationLayout() {
             title={t('nav.vulnerabilities')}
             to="/vulnerabilities"
           />
-          <Section
-            number={4}
-            title={t('nav.tracking')}
-            to="/tracking"
-          />
+          <Section number={4} title={t('nav.tracking')} to="/tracking" />
         </div>
 
         <div className="flex flex-col gap-2">

--- a/src/components/layout/NavigationLayout.tsx
+++ b/src/components/layout/NavigationLayout.tsx
@@ -50,6 +50,11 @@ export default function NavigationLayout() {
             title={t('nav.vulnerabilities')}
             to="/vulnerabilities"
           />
+          <Section
+            number={4}
+            title={t('nav.tracking')}
+            to="/tracking"
+          />
         </div>
 
         <div className="flex flex-col gap-2">

--- a/src/routes/document-information/General.tsx
+++ b/src/routes/document-information/General.tsx
@@ -1,7 +1,6 @@
 import WizardStep from '@/components/WizardStep'
 import HSplit from '@/components/forms/HSplit'
 import { Input } from '@/components/forms/Input'
-import RevisionHistoryTable from '@/components/forms/RevisionHistoryTable'
 import Select from '@/components/forms/Select'
 import { useTemplate } from '@/utils/template'
 import useDocumentStoreUpdater from '@/utils/useDocumentStoreUpdater'
@@ -11,7 +10,6 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TDocumentInformation } from './types/tDocumentInformation'
 import {
-  TDocumentStatus,
   TGeneralDocumentInformation,
   getDefaultGeneralDocumentInformation,
 } from './types/tGeneralDocumentInformation'
@@ -49,33 +47,6 @@ export default function General() {
           placeholder={getFieldPlaceholder('document-information.title')}
           isRequired
         />
-
-        <Select
-          className="w-1/2"
-          label={t('document.general.state')}
-          csafPath="/document/tracking/status"
-          isTouched={hasVisitedPage}
-          selectedKeys={[localState.status]}
-          onSelectionChange={(v) => {
-            if (!v.anchorKey) return
-
-            setLocalState({
-              ...localState,
-              status: [...v][0] as TDocumentStatus,
-            })
-          }}
-          isDisabled={isFieldReadonly('document-information.tracking.status')}
-          isRequired
-          placeholder={getFieldPlaceholder(
-            'document-information.tracking.status',
-          )}
-        >
-          {['draft', 'final', 'interim'].map((key) => (
-            <SelectItem key={key}>
-              {t(`document.general.status.${key}`)}
-            </SelectItem>
-          ))}
-        </Select>
       </HSplit>
       <HSplit className="items-start">
         <Input
@@ -108,7 +79,6 @@ export default function General() {
           ))}
         </Select>
       </HSplit>
-      <RevisionHistoryTable />
     </WizardStep>
   )
 }

--- a/src/routes/document-information/Tracking.tsx
+++ b/src/routes/document-information/Tracking.tsx
@@ -8,7 +8,11 @@ import usePageVisit from '@/utils/validation/usePageVisit'
 import { SelectItem } from '@heroui/select'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { getDefaultGeneralDocumentInformation, TDocumentStatus, TGeneralDocumentInformation } from './types/tGeneralDocumentInformation'
+import {
+  getDefaultGeneralDocumentInformation,
+  TDocumentStatus,
+  TGeneralDocumentInformation,
+} from './types/tGeneralDocumentInformation'
 import { TDocumentInformation } from './types/tDocumentInformation'
 
 export default function Tracking() {

--- a/src/routes/document-information/Tracking.tsx
+++ b/src/routes/document-information/Tracking.tsx
@@ -1,0 +1,67 @@
+import WizardStep from '@/components/WizardStep'
+import HSplit from '@/components/forms/HSplit'
+import RevisionHistoryTable from '@/components/forms/RevisionHistoryTable'
+import Select from '@/components/forms/Select'
+import { useTemplate } from '@/utils/template'
+import useDocumentStoreUpdater from '@/utils/useDocumentStoreUpdater'
+import usePageVisit from '@/utils/validation/usePageVisit'
+import { SelectItem } from '@heroui/select'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { getDefaultGeneralDocumentInformation, TDocumentStatus, TGeneralDocumentInformation } from './types/tGeneralDocumentInformation'
+import { TDocumentInformation } from './types/tDocumentInformation'
+
+export default function Tracking() {
+  const [localState, setLocalState] = useState<TGeneralDocumentInformation>(
+    getDefaultGeneralDocumentInformation(),
+  )
+
+  useDocumentStoreUpdater<TDocumentInformation>({
+    localState,
+    valueField: 'documentInformation',
+    valueUpdater: 'updateDocumentInformation',
+    init: setLocalState,
+  })
+
+  const hasVisitedPage = usePageVisit()
+  const { t } = useTranslation()
+  const { isFieldReadonly, getFieldPlaceholder } = useTemplate()
+
+  return (
+    <WizardStep
+      title={t('nav.tracking')}
+      onBack={'/vulnerabilities'}
+      progress={5}
+    >
+      <HSplit className="items-start">
+        <Select
+          className="w-1/2"
+          label={t('document.general.state')}
+          csafPath="/document/tracking/status"
+          isTouched={hasVisitedPage}
+          selectedKeys={[localState.status]}
+          onSelectionChange={(v) => {
+            if (!v.anchorKey) return
+
+            setLocalState({
+              ...localState,
+              status: [...v][0] as TDocumentStatus,
+            })
+          }}
+          isDisabled={isFieldReadonly('document-information.tracking.status')}
+          isRequired
+          placeholder={getFieldPlaceholder(
+            'document-information.tracking.status',
+          )}
+        >
+          {['draft', 'final', 'interim'].map((key) => (
+            <SelectItem key={key}>
+              {t(`document.general.status.${key}`)}
+            </SelectItem>
+          ))}
+        </Select>
+      </HSplit>
+      <RevisionHistoryTable />
+    </WizardStep>
+  )
+}

--- a/src/routes/vulnerabilities/Vulnerabilities.tsx
+++ b/src/routes/vulnerabilities/Vulnerabilities.tsx
@@ -47,6 +47,7 @@ export default function Vulnerabilities() {
       title={t('nav.vulnerabilities')}
       progress={3}
       onBack={'/product-management'}
+      onContinue={'/tracking'}
     >
       {(hasVisitedPage || listValidation.isTouched) &&
         listValidation.hasErrors && (

--- a/src/utils/validation/usePathValidation.ts
+++ b/src/utils/validation/usePathValidation.ts
@@ -7,10 +7,13 @@ const validationSections: Record<string, HasErrorFunction> = {
     return (
       ['/document/title', '/document/tracking/id', '/document/lang'].some(
         (path) => errorPaths.includes(path),
-      ) ||
-      errorPaths.some((path) =>
-        path.startsWith('/document/tracking/revision_history'),
       )
+    )
+  },
+  '/tracking': (errorPaths) => {
+    return (
+      errorPaths.includes('/document/tracking/status') ||
+      errorPaths.some((path) => path.startsWith('/document/tracking/revision_history'))
     )
   },
   '/document-information/notes': (errorPaths) => {

--- a/src/utils/validation/usePathValidation.ts
+++ b/src/utils/validation/usePathValidation.ts
@@ -4,16 +4,16 @@ type HasErrorFunction = (errorPaths: string[]) => boolean
 
 const validationSections: Record<string, HasErrorFunction> = {
   '/document-information/general': (errorPaths) => {
-    return (
-      ['/document/title', '/document/tracking/id', '/document/lang'].some(
-        (path) => errorPaths.includes(path),
-      )
+    return ['/document/title', '/document/tracking/id', '/document/lang'].some(
+      (path) => errorPaths.includes(path),
     )
   },
   '/tracking': (errorPaths) => {
     return (
       errorPaths.includes('/document/tracking/status') ||
-      errorPaths.some((path) => path.startsWith('/document/tracking/revision_history'))
+      errorPaths.some((path) =>
+        path.startsWith('/document/tracking/revision_history'),
+      )
     )
   },
   '/document-information/notes': (errorPaths) => {


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
Users usually add a new revision to their document at the end before exporting the document. That's why this PR moves the revision history and the document status into its own step at the end of the process.

## Related Tickets & Documents
- Closes #81 
