### PR TITLE
feat: Add validation of cvss v4 and dynamic version type

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -144,8 +144,11 @@
       },
       "scores": "Bewertungen",
       "score": {
-        "title": "Bewertung",
+        "title": "CVSS Bewertung",
         "cvss": "CVSS",
+        "vectorStringDescription": "CVSS 3.1 und CVSS 4.0 werden unterstützt",
+        "vectorStringEmptyError": "Der Vektorstring darf nicht leer sein.",
+        "vectorStringInvalidError": "Der eingegebene Vektorstring ist ungültig. Bitte überprüfen Sie das Format.",
         "baseScore": "Basis Bewertung",
         "baseScoreDescription": "Basis Bewertung wird aus dem Vektorstring berechnet",
         "baseSeverity": "Basis Schweregrad",

--- a/locales/en.json
+++ b/locales/en.json
@@ -146,6 +146,9 @@
       "score": {
         "title": "Score",
         "cvss": "CVSS",
+        "vectorStringDescription": "CVSS 3.1 and CVSS 4.0 are supported",
+        "vectorStringEmptyError": "The vector string cannot be empty.",
+        "vectorStringInvalidError": "The given vector string is not valid. Please check the format.",
         "baseScore": "Base Score",
         "baseScoreDescription": "Base score is calculated from the vector string",
         "baseSeverity": "Base Severity",

--- a/src/components/forms/Input.tsx
+++ b/src/components/forms/Input.tsx
@@ -21,6 +21,7 @@ export function Input(
     onValueChange,
     isInvalid,
     value: propValue,
+    errorMessage,
     ...rest
   } = props
   const validation = useFieldValidation(csafPath)
@@ -48,7 +49,10 @@ export function Input(
         inputWrapper: 'border-1 shadow-none',
       }}
       value={debouncedValue}
-      errorMessage={validation.errorMessages.map((m) => m.message).join(', ')}
+      errorMessage={
+        validation.errorMessages.map((m) => m.message).join(', ') ||
+        errorMessage
+      }
       isInvalid={
         isInvalid ||
         (!isDebouncing &&

--- a/src/routes/vulnerabilities/Remediations.tsx
+++ b/src/routes/vulnerabilities/Remediations.tsx
@@ -170,7 +170,7 @@ function RemediationForm({
           csafPath={`${csafPath}/date`}
           value={remediation.date}
           onChange={(newValue) => onChange({ ...remediation, date: newValue })}
-          isDisabled={checkReadOnly(remediation, 'details')}
+          isDisabled={checkReadOnly(remediation, 'date')}
         />
       </HSplit>
       <Textarea
@@ -182,6 +182,7 @@ function RemediationForm({
           onChange({ ...remediation, details: newValue })
         }
         isDisabled={checkReadOnly(remediation, 'details')}
+        isRequired
         placeholder={getPlaceholder(remediation, 'details')}
       />
       <Input

--- a/src/routes/vulnerabilities/Vulnerabilities.tsx
+++ b/src/routes/vulnerabilities/Vulnerabilities.tsx
@@ -107,10 +107,12 @@ function TabTitle({
   title,
   csafPrefix = '',
   csafPaths = [],
+  hasError: hasPassedError = false,
 }: {
   title: string
   csafPrefix?: string
   csafPaths?: string[]
+  hasError?: boolean
 }) {
   const messages = useValidationStore((state) => state.messages)
   const errorPaths = messages
@@ -125,6 +127,10 @@ function TabTitle({
 
   if (!hasError && csafPaths.length > 0) {
     hasError = csafPaths.some((path) => errorPaths.includes(path))
+  }
+
+  if (!hasError) {
+    hasError = hasPassedError
   }
 
   return (
@@ -208,6 +214,9 @@ function VulnerabilityForm({
             <TabTitle
               title={t('vulnerabilities.scores')}
               csafPrefix={`${prefix}/scores`}
+              hasError={vulnerability.scores.some(
+                (score) => !score.cvssVersion,
+              )}
             />
           }
         >

--- a/src/routes/vulnerabilities/types/tVulnerabilityScore.ts
+++ b/src/routes/vulnerabilities/types/tVulnerabilityScore.ts
@@ -1,6 +1,6 @@
 import { uid } from 'uid'
 
-export type TCvssVersion = '3.1'
+export type TCvssVersion = '3.0' | '3.1' | '4.0' | null
 
 export type TVulnerabilityScore = {
   id: string
@@ -12,7 +12,7 @@ export type TVulnerabilityScore = {
 export function getDefaultVulnerabilityScore(): TVulnerabilityScore {
   return {
     id: uid(),
-    cvssVersion: '3.1',
+    cvssVersion: null,
     vectorString: '',
     productIds: [],
   }

--- a/src/utils/csafExport/csafExport.ts
+++ b/src/utils/csafExport/csafExport.ts
@@ -150,7 +150,7 @@ export function createCSAFDocument(documentStore: TDocumentStore) {
           remediations: vulnerability.remediations?.map((remediation) => ({
             category: remediation.category,
             date: remediation.date || undefined,
-            details: remediation.details || undefined,
+            details: remediation.details,
             url: remediation.url || undefined,
             product_ids: remediation.productIds.map((id) =>
               pidGenerator.getPid(id),

--- a/src/utils/csafExport/parseScore.ts
+++ b/src/utils/csafExport/parseScore.ts
@@ -1,0 +1,31 @@
+import { TVulnerabilityScore } from '@/routes/vulnerabilities/types/tVulnerabilityScore'
+import { calculateBaseScore, calculateQualScore } from 'cvss4'
+import { PidGenerator } from './pidGenerator'
+
+export default function parseScore(
+  score: TVulnerabilityScore,
+  pidGenerator: PidGenerator,
+) {
+  let baseScore = 0
+  let baseSeverity = ''
+
+  try {
+    baseScore = calculateBaseScore(score.vectorString)
+    baseSeverity = calculateQualScore(baseScore).toUpperCase()
+  } catch {
+    // If the score is invalid, we leave baseScore and baseSeverity as defaults
+    // as there will be errors already in the vectorString
+  }
+
+  const key = score.cvssVersion === '3.1' ? 'cvss_v3' : 'cvss_v4'
+
+  return {
+    [key]: {
+      version: score.cvssVersion,
+      vectorString: score.vectorString,
+      baseScore,
+      baseSeverity,
+    },
+    products: score.productIds.map((id) => pidGenerator.getPid(id)),
+  }
+}

--- a/src/utils/validation/documentValidator.ts
+++ b/src/utils/validation/documentValidator.ts
@@ -48,6 +48,11 @@ export async function validateDocument(
       })
     })
 
+    // Ignore /vulnerabilities/%d/scores/%d	for now due to https://github.com/sec-o-simple/sec-o-simple/issues/32
+    // csaf validator lib will return an error when we set cvss_v4
+    const pattern = /^\/vulnerabilities\/\d+\/scores\/\d+$/
+    messages = messages.filter((m) => !pattern.test(m.path))
+
     return {
       // We want to use result.isValid when we implemented all fields
       // but for now we use the messages length to determine if the document is valid


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
Previously we only exported CVSS 3.1. This PR enables users to use CVSS 4.0 scores as well. I needed to add "custom" validation logic as the csaf-validator-lib with CSAF 2.0 does not seem to support the `cvss_v4` property. That's why we, for now, need to ignore an error returned by the library.

- Example for CVSS 3.1: `CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H`
- Example for CVSS 4.0: `CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N`

## Screenshots
<img width="870" height="645" alt="image" src="https://github.com/user-attachments/assets/2df6c39d-7508-4ca5-9a5d-a1a9d90f5ae1" />

## Related Tickets & Documents

- Closes #61 
- Closes partially #32 : I'll keep this issue open for now
