### PR TITLE
remove description and export product description

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -185,6 +185,7 @@
       "title": "Notiz Titel",
       "note": "Notiz",
       "notes": "Notizen",
+      "productDescription": "Produktbeschreibung für {{productName}}",
       "content": "Notiz Inhalt",
       "category": "Notiz Kategorie",
       "category_plural": "Kategorien",

--- a/locales/en.json
+++ b/locales/en.json
@@ -185,6 +185,7 @@
       "title": "Note Title",
       "note": "Note",
       "notes": "Notes",
+      "productDescription": "Product Description for {{productName}}",
       "content": "Note Content",
       "category": "Note Category",
       "category_plural": "Categories",

--- a/src/routes/products/Product.tsx
+++ b/src/routes/products/Product.tsx
@@ -33,7 +33,7 @@ export default function Product() {
   }
 
   return (
-    <WizardStep noContentWrapper={true}>
+    <WizardStep progress={2} noContentWrapper={true}>
       <SubMenuHeader
         title={
           product.name
@@ -75,7 +75,6 @@ export default function Product() {
       {product.subBranches.map((version) => (
         <InfoCard
           title={getPTBName(version) ?? t('untitled.product_version')}
-          linkTo={`/product-management/version/${version.id}`}
           key={version.id}
           variant="boxed"
           onEdit={() => {
@@ -83,6 +82,11 @@ export default function Product() {
             onOpen()
           }}
           onDelete={() => deletePTB(version.id)}
+          linkTo={
+            sosDocumentType !== 'Software'
+              ? `/product-management/version/${version.id}`
+              : undefined
+          }
           endContent={
             sosDocumentType !== 'Software' ? (
               <IconButton
@@ -96,9 +100,7 @@ export default function Product() {
               />
             ) : undefined
           }
-        >
-          {version.description && <div>{version.description}</div>}
-        </InfoCard>
+        />
       ))}
     </WizardStep>
   )

--- a/src/routes/products/VendorList.tsx
+++ b/src/routes/products/VendorList.tsx
@@ -1,18 +1,18 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useListState } from '@/utils/useListState'
 import ComponentList from '@/components/forms/ComponentList'
+import useDocumentStoreUpdater from '@/utils/useDocumentStoreUpdater'
+import { useListState } from '@/utils/useListState'
+import { useProductTreeBranch } from '@/utils/useProductTreeBranch'
+import { faAdd, faEdit } from '@fortawesome/free-solid-svg-icons'
+import { Modal, useDisclosure } from '@heroui/modal'
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import ProductCard from './components/ProductCard'
+import { PTBEditForm } from './components/PTBEditForm'
 import {
   TProductTreeBranch,
   getDefaultProductTreeBranch,
 } from './types/tProductTreeBranch'
-import useDocumentStoreUpdater from '@/utils/useDocumentStoreUpdater'
-import ProductCard from './components/ProductCard'
-import { useEffect, useMemo, useState } from 'react'
-import { PTBEditForm } from './components/PTBEditForm'
-import { useProductTreeBranch } from '@/utils/useProductTreeBranch'
-import { Modal, useDisclosure } from '@heroui/modal'
-import { faAdd, faEdit } from '@fortawesome/free-solid-svg-icons'
-import { useTranslation } from 'react-i18next'
 
 export default function VendorList() {
   const { t } = useTranslation()
@@ -61,9 +61,6 @@ export default function VendorList() {
         itemLabel={t('products.vendor.label')}
         title="name"
         titleProps={{ className: 'font-bold' }}
-        endContent={(item) => (
-          <div className="text-neutral-foreground">{item.description}</div>
-        )}
         customActions={[
           {
             icon: faAdd,

--- a/src/routes/products/components/InfoCard.tsx
+++ b/src/routes/products/components/InfoCard.tsx
@@ -2,6 +2,7 @@ import HSplit from '@/components/forms/HSplit'
 import IconButton from '@/components/forms/IconButton'
 import VSplit from '@/components/forms/VSplit'
 import { faEdit, faTrash } from '@fortawesome/free-solid-svg-icons'
+import { cn } from '@heroui/theme'
 import { HTMLProps, PropsWithChildren, ReactNode } from 'react'
 import { Link } from 'react-router'
 
@@ -9,6 +10,7 @@ export type InfoCardProps = HTMLProps<HTMLDivElement> &
   PropsWithChildren<{
     variant?: 'boxed' | 'plain'
     title: string
+    description?: string
     startContent?: ReactNode
     endContent?: ReactNode
     linkTo?: string
@@ -22,6 +24,7 @@ export default function InfoCard(props: InfoCardProps) {
   } else {
     const {
       title,
+      description,
       startContent,
       endContent,
       linkTo,
@@ -35,9 +38,15 @@ export default function InfoCard(props: InfoCardProps) {
         <HSplit className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             {startContent}
-            <div className="font-bold">
+            <div
+              className={cn('font-bold', {
+                'hover:underline': linkTo,
+              })}
+            >
               {linkTo ? <Link to={linkTo}>{title}</Link> : title}
             </div>
+
+            <div className="text-neutral-foreground">{description}</div>
           </div>
           <div>
             {endContent}

--- a/src/routes/products/components/PTBEditForm.tsx
+++ b/src/routes/products/components/PTBEditForm.tsx
@@ -48,13 +48,17 @@ export function PTBEditForm({ ptb, onSave }: PTBEditFormProps) {
               isDisabled={!ptb || checkReadOnly(ptb, 'name')}
               placeholder={ptb ? getPlaceholder(ptb, 'name') : undefined}
             />
-            <Textarea
-              label={t(`${ptb?.category}.description`)}
-              value={description}
-              onValueChange={setDescription}
-              isDisabled={!ptb || checkReadOnly(ptb, 'description')}
-              placeholder={ptb ? getPlaceholder(ptb, 'description') : undefined}
-            />
+            {ptb?.category === 'product_name' && (
+              <Textarea
+                label={t(`${ptb?.category}.description`)}
+                value={description}
+                onValueChange={setDescription}
+                isDisabled={!ptb || checkReadOnly(ptb, 'description')}
+                placeholder={
+                  ptb ? getPlaceholder(ptb, 'description') : undefined
+                }
+              />
+            )}
             {ptb?.category === 'product_name' && (
               <Select
                 label={t(`${ptb?.category}.type`)}

--- a/src/routes/products/components/ProductCard.tsx
+++ b/src/routes/products/components/ProductCard.tsx
@@ -26,6 +26,7 @@ export default function ProductCard({ product, ...props }: ProductCardProps) {
       title={
         getPTBName(product) ?? t(`untitled.${product.category?.toLowerCase()}`)
       }
+      description={product.description}
       linkTo={`product/${product.id}`}
       startContent={
         <Chip color="primary" variant="flat" radius="md" size="lg">

--- a/src/routes/products/components/ProductDatabaseSelector.tsx
+++ b/src/routes/products/components/ProductDatabaseSelector.tsx
@@ -1,26 +1,26 @@
 import { Input } from '@/components/forms/Input'
+import { TProductTreeBranch } from '@/routes/products/types/tProductTreeBranch'
+import { useConfigStore } from '@/utils/useConfigStore'
+import {
+  Vendor as DatabaseVendor,
+  Product,
+  useDatabaseClient,
+} from '@/utils/useDatabaseClient'
+import useDocumentStore from '@/utils/useDocumentStore'
 import { faSearch } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button } from '@heroui/button'
 import {
   Modal,
-  ModalContent,
-  ModalHeader,
   ModalBody,
+  ModalContent,
   ModalFooter,
+  ModalHeader,
 } from '@heroui/modal'
 import { Accordion, AccordionItem, Alert, Checkbox } from '@heroui/react'
 import { useEffect, useState } from 'react'
-import { Link } from 'react-router'
-import {
-  useDatabaseClient,
-  Product,
-  Vendor as DatabaseVendor,
-} from '@/utils/useDatabaseClient'
-import { useConfigStore } from '@/utils/useConfigStore'
-import { TProductTreeBranch } from '@/routes/products/types/tProductTreeBranch'
 import { useTranslation } from 'react-i18next'
-import useDocumentStore from '@/utils/useDocumentStore'
+import { Link } from 'react-router'
 
 interface Props {
   isOpen: boolean
@@ -135,7 +135,7 @@ export default function ProductDatabaseSelector({ isOpen, onClose }: Props) {
                   id: version.id,
                   category: 'product_version',
                   name: version.name,
-                  description: version.description,
+                  description: '',
                   subBranches: [],
                 })),
               }

--- a/src/utils/csafExport/csafExport.ts
+++ b/src/utils/csafExport/csafExport.ts
@@ -8,6 +8,7 @@ import useValidationStore from '../validation/useValidationStore'
 import generateRelationships from './generateRelationships'
 import { retrieveLatestVersion } from './latestVersion'
 import { parseNote } from './parseNote'
+import { parseNotes } from './parseNotes'
 import { parseProductTreeBranches } from './parseProductTreeBranches'
 import parseScore from './parseScore'
 import { PidGenerator } from './pidGenerator'
@@ -31,6 +32,8 @@ export function createCSAFDocument(documentStore: TDocumentStore) {
       ? products.flatMap((p) => p.versions.map((v) => pidGenerator.getPid(v)))
       : undefined
   }
+
+  const notes = parseNotes(documentStore)
 
   const csafDocument = {
     document: {
@@ -70,10 +73,7 @@ export function createCSAFDocument(documentStore: TDocumentStore) {
         name: documentInformation.publisher.name,
         namespace: documentInformation.publisher.namespace,
       },
-      notes:
-        documentInformation.notes.length > 0
-          ? documentInformation.notes.map(parseNote)
-          : undefined,
+      notes: notes.length > 0 ? notes : undefined,
       references:
         documentInformation.references.length > 0
           ? documentInformation.references?.map((reference) => ({

--- a/src/utils/csafExport/parseNotes.ts
+++ b/src/utils/csafExport/parseNotes.ts
@@ -1,0 +1,31 @@
+import { TDocumentInformation } from '@/routes/document-information/types/tDocumentInformation'
+import { TProductTreeBranch } from '@/routes/products/types/tProductTreeBranch'
+import { TDocumentStore } from '../useDocumentStore'
+import { parseNote, TParsedNote } from './parseNote'
+
+function extractAllProducts(
+  products: TProductTreeBranch[],
+): TProductTreeBranch[] {
+  return products?.flatMap((vendor) => {
+    return vendor.subBranches?.flatMap((product) => product)
+  })
+}
+
+export function parseNotes(documentStore: TDocumentStore): TParsedNote[] {
+  const documentInformation: TDocumentInformation =
+    documentStore.documentInformation
+  const notes = documentInformation.notes.map(parseNote)
+
+  const productNotes = extractAllProducts(
+    Object.values(documentStore.products),
+  )?.map((product) => ({
+    category: 'description',
+    text: product.description || '',
+    title:
+      documentInformation.lang === 'de'
+        ? `Produktbeschreibung für ${product.name}`
+        : `Product description for ${product.name}`,
+  }))
+
+  return [...notes, ...productNotes] as TParsedNote[]
+}

--- a/src/utils/useDocumentStoreUpdater.ts
+++ b/src/utils/useDocumentStoreUpdater.ts
@@ -1,8 +1,8 @@
 import { useEffect } from 'react'
-import useDocumentStore, { TDocumentStore } from './useDocumentStore'
 import { useConfigStore } from './useConfigStore'
-import useValidationStore from './validation/useValidationStore'
+import useDocumentStore, { TDocumentStore } from './useDocumentStore'
 import { validateDocument } from './validation/documentValidator'
+import useValidationStore from './validation/useValidationStore'
 
 type TDocumentStoreFunction<T> = {
   [K in keyof TDocumentStore]: TDocumentStore[K] extends (update: T) => void


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
Descriptions for Vendors and Versions are not necessary anymore. 
Descriptions of products are stored as notes of the type "description" with the name of the product.

The breadcrumb progress state got fixed for the product view.

## Related Tickets & Documents

- Closes #72 #96 
