### PR TITLE
only add entry if actually saved, and not cancelled

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -35,7 +35,7 @@
     "nav": {
       "home": "Startseite",
       "products": "Produkte",
-      "vendors": "Anbieter",
+      "vendors": "Hersteller",
       "document": "Dokument",
       "documentInfo": "Dokument Informationen",
       "vulnerabilities": "Schwachstellen",
@@ -112,7 +112,7 @@
           "other": "Andere",
           "translator": "Übersetzer",
           "user": "Benutzer",
-          "vendor": "Anbieter"
+          "vendor": "Hersteller"
         }
       },
       "references": {
@@ -180,7 +180,7 @@
           "mitigation": "Minderung",
           "no_fix_planned": "Keine Behebung geplant",
           "none_available": "Keine verfügbar",
-          "vendor_fix": "Anbieterbehebung",
+          "vendor_fix": "Herstellerbehebung",
           "workaround": "Workaround"
         },
         "date": "Datum",
@@ -226,18 +226,19 @@
       }
     },
     "untitled": {
-      "vendor": "Unbenannter Anbieter",
+      "vendor": "Unbenannter Hersteller",
       "product_name": "Unbenanntes Produkt",
       "product_version": "Unbenannte Produktversion",
       "": "Unbenannt"
     },
     "modal": {
-      "edit": "{{label}} bearbeiten"
+      "edit": "{{label}} bearbeiten",
+      "create": "{{label}} erstellen"
     },
     "vendor": {
-      "label": "Anbieter",
-      "name": "Anbietername",
-      "description": "Anbieterbeschreibung"
+      "label": "Hersteller",
+      "name": "Name",
+      "description": "Beschreibung"
     },
     "product_version": {
       "label": "Version",
@@ -256,23 +257,25 @@
         "description": "Wähle ein oder mehrere Produkte aus deiner bestehenden Produktdatenbank aus, um sie zu deinem Dokument hinzuzufügen.",
         "database": "Datenbank",
         "warning": "Änderungen an den hinzugefügten Produkten werden nicht gespeichert. Um Produkte zu bearbeiten, hinzuzufügen oder zu löschen, besuche bitte die",
-        "noVendors": "Keine Anbieter in der Datenbank gefunden. Bitte füge Anbieter und Produkte zur Datenbank hinzu, bevor du diese Funktion verwendest.",
-        "searchPlaceholder": "Anbieter und Produkte suchen",
+        "noVendors": "Keine Hersteller in der Datenbank gefunden. Bitte füge Hersteller und Produkte zur Datenbank hinzu, bevor du diese Funktion verwendest.",
+        "searchPlaceholder": "Hersteller und Produkte suchen",
         "selectedAll": "Alle Produkte ausgewählt",
         "selected_one": "1 Produkt ausgewählt",
         "selected_other": "{{count}} Produkte ausgewählt",
         "add_one": "1 Produkt hinzufügen",
         "add_other": "{{count}} Produkte hinzufügen"
       },
-      "vendors": "Anbieter",
+      "vendors": "Hersteller",
       "products": "Produkte",
       "manage": "Produktverwaltung",
-      "empty": "Sie haben noch kein {{ type }}-Produkt erstellt.\nSie können eines hinzufügen, indem Sie einen Anbieter erstellen und ihm ein Produkt hinzufügen.",
+      "empty": "Sie haben noch kein {{ type }}-Produkt erstellt.\nSie können eines hinzufügen, indem Sie einen Hersteller erstellen und ihm ein Produkt hinzufügen.",
       "software": "Software",
       "hardware": "Hardware",
-      "unknownType": "Unknown Type",
+      "unknownType": "Unbekannter Typ",
       "vendor": {
-        "label": "Anbieter"
+        "label": "Hersteller",
+        "addProduct": "Produkt hinzufügen",
+        "edit": "Hersteller bearbeiten"
       },
       "product": {
         "label": "Produkt",

--- a/locales/en.json
+++ b/locales/en.json
@@ -232,22 +232,23 @@
       "": "Untitled"
     },
     "modal": {
-      "edit": "Edit {{label}}"
+      "edit": "Edit {{label}}",
+      "create": "Create {{label}}"
     },
     "vendor": {
       "label": "Vendor",
-      "name": "Vendor Name",
-      "description": "Vendor Description"
+      "name": "Name",
+      "description": "Description"
     },
     "product_version": {
       "label": "Version",
-      "name": "Version Name",
-      "description": "Version Description"
+      "name": "Name",
+      "description": "Description"
     },
     "product_name": {
       "label": "Product",
-      "name": "Product Name",
-      "description": "Product Description",
+      "name": "Name",
+      "description": "Description",
       "type": "Product Type"
     },
     "products": {
@@ -272,7 +273,9 @@
       "hardware": "Hardware",
       "unknownType": "Unknown Type",
       "vendor": {
-        "label": "Vendor"
+        "label": "Vendor",
+        "addProduct": "Add Product",
+        "edit": "Edit Vendor"
       },
       "product": {
         "label": "Product",

--- a/src/components/forms/ComponentList.tsx
+++ b/src/components/forms/ComponentList.tsx
@@ -16,6 +16,7 @@ import IconButton from './IconButton'
 
 export type CustomAction<T> = {
   icon: FontAwesomeIconProps['icon']
+  tooltip?: string
   onClick: (item: T) => void
   notAffectedByReadonly?: boolean
 }
@@ -33,7 +34,7 @@ export type ComponentListProps<T> = {
   titleProps?: HTMLProps<HTMLDivElement>
   customActions?: CustomAction<T>[]
   itemBgColor?: string
-  postAddAction?: (item: T) => void
+  addEntry?: () => void
   renderTitlePrefix?: (item: T) => ReactNode
 }
 
@@ -47,11 +48,13 @@ export default function ComponentList<T extends object>({
   titleProps,
   customActions,
   itemBgColor,
-  postAddAction,
+  addEntry,
   ...props
 }: ComponentListProps<T>) {
   const { t } = useTranslation()
-  const [expandedKeys, setExpandedKeys] = useState<Selection>(new Set([]))
+  const [expandedKeys, setExpandedKeys] = useState<Selection>(
+    new Set(listState.data.map((item) => listState.getId(item))),
+  )
 
   return (
     <div className="flex flex-col gap-2">
@@ -104,6 +107,7 @@ export default function ComponentList<T extends object>({
                         <IconButton
                           key={i}
                           icon={action.icon}
+                          tooltip={action.tooltip}
                           onPress={() => action.onClick(item)}
                           isDisabled={
                             !action.notAffectedByReadonly && checkReadOnly(item)
@@ -112,6 +116,9 @@ export default function ComponentList<T extends object>({
                       ))}
                     <IconButton
                       icon={faTrash}
+                      tooltip={t('common.delete', {
+                        label: itemLabel,
+                      })}
                       onPress={() =>
                         onDelete
                           ? onDelete?.(item)
@@ -136,12 +143,14 @@ export default function ComponentList<T extends object>({
           label: itemLabel,
         })}
         onPress={() => {
+          if (addEntry) {
+            addEntry()
+            return
+          }
+
           const item = listState.addDataEntry()
-          // expand new item
           if (item) {
             setExpandedKeys(new Set([...expandedKeys, listState.getId(item)]))
-
-            postAddAction?.(item)
           }
         }}
       />

--- a/src/routes/products/VendorList.tsx
+++ b/src/routes/products/VendorList.tsx
@@ -1,14 +1,16 @@
 /* eslint-disable react-hooks/exhaustive-deps */
+import AddItemButton from '@/components/forms/AddItemButton'
 import ComponentList from '@/components/forms/ComponentList'
+import VSplit from '@/components/forms/VSplit'
 import useDocumentStoreUpdater from '@/utils/useDocumentStoreUpdater'
 import { useListState } from '@/utils/useListState'
 import { useProductTreeBranch } from '@/utils/useProductTreeBranch'
-import { faAdd, faEdit } from '@fortawesome/free-solid-svg-icons'
+import { faEdit } from '@fortawesome/free-solid-svg-icons'
 import { Modal, useDisclosure } from '@heroui/modal'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import ProductCard from './components/ProductCard'
-import { PTBEditForm } from './components/PTBEditForm'
+import { PTBCreateEditForm } from './components/PTBEditForm'
 import {
   TProductTreeBranch,
   getDefaultProductTreeBranch,
@@ -16,7 +18,7 @@ import {
 
 export default function VendorList() {
   const { t } = useTranslation()
-  const { rootBranch, updatePTB, deletePTB, getPTBsByCategory } =
+  const { rootBranch, updatePTB, addPTB, deletePTB, getPTBsByCategory } =
     useProductTreeBranch()
 
   const vendorListState = useListState<TProductTreeBranch>({
@@ -48,57 +50,120 @@ export default function VendorList() {
   })
 
   // modal variables
-  const { isOpen, onOpen, onOpenChange } = useDisclosure()
-  const [editingPTB, setEditingPTB] = useState<TProductTreeBranch | undefined>()
-  const [latestAddedPTB, setLatestAddedPTB] = useState<
+  const {
+    isOpen: isVendorOpen,
+    onOpen: onVendorOpen,
+    onOpenChange: onVendorOpenChange,
+  } = useDisclosure()
+  const {
+    isOpen: isProductOpen,
+    onOpen: onProductOpen,
+    onOpenChange: onProductOpenChange,
+  } = useDisclosure()
+
+  const [editingVendor, setEditingVendor] = useState<
+    TProductTreeBranch | undefined
+  >()
+  const [editingProduct, setEditingProduct] = useState<
     TProductTreeBranch | undefined
   >()
 
   return (
     <>
-      <Modal size="xl" isOpen={isOpen} onOpenChange={onOpenChange}>
-        <PTBEditForm ptb={editingPTB} onSave={(ptb) => updatePTB(ptb)} />
+      <Modal
+        size="xl"
+        isOpen={isVendorOpen}
+        onOpenChange={() => {
+          onVendorOpenChange()
+          setEditingVendor(undefined)
+        }}
+      >
+        <PTBCreateEditForm
+          ptb={editingVendor}
+          onSave={(ptb) => {
+            if (ptb.id) {
+              updatePTB(ptb)
+            } else {
+              const vendor = { ...vendorListState.addDataEntry(), ...ptb }
+              vendorListState.updateDataEntry(vendor)
+              addPTB(vendor)
+            }
+          }}
+          category="vendor"
+        />
       </Modal>
+
       <ComponentList
         listState={vendorListState}
         itemLabel={t('products.vendor.label')}
         title="name"
         titleProps={{ className: 'font-bold' }}
-        postAddAction={(item) => {
-          setEditingPTB(item)
-          onOpen()
-        }}
+        addEntry={() => onVendorOpen()}
         customActions={[
           {
-            icon: faAdd,
-            onClick: (vendor) => {
-              const defaultBranch = getDefaultProductTreeBranch('product_name')
-              vendorListState.updateDataEntry({
-                ...vendor,
-                subBranches: [...vendor.subBranches, defaultBranch],
-              })
-              setLatestAddedPTB(defaultBranch)
-            },
-          },
-          {
             icon: faEdit,
+            tooltip: t('products.vendor.edit'),
             onClick: (ptb) => {
-              setEditingPTB(ptb)
-              onOpen()
+              setEditingVendor(ptb)
+              onVendorOpen()
             },
           },
         ]}
-        content={(vendor) =>
-          vendor.subBranches.map((product) => (
-            <ProductCard
-              key={product.id}
-              className="border-t py-2"
-              product={product}
-              variant="plain"
-              openEditModal={product.id === latestAddedPTB?.id}
-            />
-          ))
-        }
+        content={(vendor) => {
+          return (
+            <VSplit>
+              {vendor.subBranches.map((product) => (
+                <ProductCard
+                  key={product.id}
+                  product={product}
+                  variant="boxed"
+                  onEdit={() => {
+                    setEditingProduct(product)
+                    onProductOpen()
+                  }}
+                />
+              ))}
+
+              <AddItemButton
+                fullWidth
+                label={t('common.add', {
+                  label: t('products.product.label'),
+                })}
+                onPress={() => onProductOpen()}
+              />
+
+              <Modal
+                size="xl"
+                isOpen={isProductOpen}
+                onOpenChange={() => {
+                  onProductOpenChange()
+                  setEditingProduct(undefined)
+                }}
+              >
+                <PTBCreateEditForm
+                  ptb={editingProduct}
+                  category="product_name"
+                  onSave={(ptb) => {
+                    if (ptb.id) {
+                      updatePTB(ptb)
+                    } else {
+                      vendorListState.updateDataEntry({
+                        ...vendor,
+                        subBranches: [
+                          ...vendor.subBranches,
+                          {
+                            ...getDefaultProductTreeBranch('product_name'),
+                            ...ptb,
+                          },
+                        ],
+                      })
+                    }
+                  }}
+                />
+              </Modal>
+            </VSplit>
+          )
+        }}
       />
     </>
   )

--- a/src/routes/products/Version.tsx
+++ b/src/routes/products/Version.tsx
@@ -1,4 +1,5 @@
 import Breadcrumbs from '@/components/forms/Breadcrumbs'
+import VSplit from '@/components/forms/VSplit'
 import WizardStep from '@/components/WizardStep'
 import useDocumentStore from '@/utils/useDocumentStore'
 import { useProductTreeBranch } from '@/utils/useProductTreeBranch'
@@ -134,43 +135,51 @@ export default function Version() {
             title={t(`products.relationship.categories.${category}`)}
             className="border shadow-none"
           >
-            {relationships.map((relationship) => {
-              const product = findProductTreeBranch(relationship.productId2)
+            <VSplit>
+              {relationships.map((relationship) => {
+                const product = findProductTreeBranch(relationship.productId2)
 
-              return product ? (
-                <InfoCard
-                  key={relationship.id}
-                  variant="plain"
-                  title={
-                    product.name !== '' && product.name
-                      ? product.name
-                      : t('untitled.product_name')
-                  }
-                  className="border-t py-2"
-                  onEdit={() => {
-                    setEditingRelationship(relationship)
-                    onOpen()
-                  }}
-                  onDelete={() => deleteRelationship(relationship)}
-                  startContent={
-                    <Chip color="primary" variant="flat" radius="md" size="lg">
-                      {product.type}
-                    </Chip>
-                  }
-                >
-                  {relationship.product2VersionIds.length > 0 && (
-                    <TagList
-                      items={relationship.product2VersionIds}
-                      linkGenerator={(x) => `/product-management/version/${x}`}
-                      labelGenerator={(x) =>
-                        getPTBName(findProductTreeBranch(x)) ??
-                        t('untitled.product_version')
-                      }
-                    />
-                  )}
-                </InfoCard>
-              ) : undefined
-            })}
+                return product ? (
+                  <InfoCard
+                    key={relationship.id}
+                    variant="boxed"
+                    title={
+                      product.name !== '' && product.name
+                        ? product.name
+                        : t('untitled.product_name')
+                    }
+                    onEdit={() => {
+                      setEditingRelationship(relationship)
+                      onOpen()
+                    }}
+                    onDelete={() => deleteRelationship(relationship)}
+                    startContent={
+                      <Chip
+                        color="primary"
+                        variant="flat"
+                        radius="md"
+                        size="lg"
+                      >
+                        {product.type}
+                      </Chip>
+                    }
+                  >
+                    {relationship.product2VersionIds.length > 0 && (
+                      <TagList
+                        items={relationship.product2VersionIds}
+                        linkGenerator={(x) =>
+                          `/product-management/version/${x}`
+                        }
+                        labelGenerator={(x) =>
+                          getPTBName(findProductTreeBranch(x)) ??
+                          t('untitled.product_version')
+                        }
+                      />
+                    )}
+                  </InfoCard>
+                ) : undefined
+              })}
+            </VSplit>
           </AccordionItem>
         ))}
       </Accordion>

--- a/src/routes/products/components/PTBEditForm.tsx
+++ b/src/routes/products/components/PTBEditForm.tsx
@@ -1,6 +1,7 @@
 import { Input, Textarea } from '@/components/forms/Input'
 import Select from '@/components/forms/Select'
 import { checkReadOnly, getPlaceholder } from '@/utils/template'
+import useDocumentType from '@/utils/useDocumentType'
 import { Button } from '@heroui/button'
 import {
   ModalBody,
@@ -15,18 +16,22 @@ import {
   TProductTreeBranch,
   TProductTreeBranchProductType,
 } from '../types/tProductTreeBranch'
-import useDocumentType from '@/utils/useDocumentType'
 
-export type PTBEditFormProps = {
+export type PTBCreateEditFormProps = {
   ptb?: TProductTreeBranch
   onSave?: (updatedPtb: TProductTreeBranch) => void
+  category?: string
 }
 
-export function PTBEditForm({ ptb, onSave }: PTBEditFormProps) {
+export function PTBCreateEditForm({
+  ptb,
+  onSave,
+  category,
+}: PTBCreateEditFormProps) {
   const { t } = useTranslation()
   const [name, setName] = useState(ptb?.name ?? '')
   const [description, setDescription] = useState(ptb?.description ?? '')
-  const [type, setType] = useState(ptb?.type)
+  const [type, setType] = useState(ptb?.type ?? 'Software')
   const { hasHardware, hasSoftware } = useDocumentType()
 
   return (
@@ -34,33 +39,37 @@ export function PTBEditForm({ ptb, onSave }: PTBEditFormProps) {
       {(onClose) => (
         <>
           <ModalHeader>
-            {t('modal.edit', {
-              label: t(`${ptb?.category}.label`),
-            })}
+            {ptb?.id
+              ? t('modal.edit', {
+                  label: t(`${category}.label`),
+                })
+              : t('modal.create', {
+                  label: t(`${category}.label`),
+                })}
           </ModalHeader>
           <ModalBody>
             <Input
-              label={t(`${ptb?.category}.name`)}
+              label={t(`${category}.name`)}
               autoFocus
               value={name}
               onValueChange={setName}
-              isDisabled={!ptb || checkReadOnly(ptb, 'name')}
+              isDisabled={ptb ? checkReadOnly(ptb, 'name') : false}
               placeholder={ptb ? getPlaceholder(ptb, 'name') : undefined}
             />
-            {ptb?.category === 'product_name' && (
+            {category === 'product_name' && (
               <Textarea
-                label={t(`${ptb?.category}.description`)}
+                label={t(`${category}.description`)}
                 value={description}
                 onValueChange={setDescription}
-                isDisabled={!ptb || checkReadOnly(ptb, 'description')}
+                isDisabled={ptb ? checkReadOnly(ptb, 'description') : false}
                 placeholder={
                   ptb ? getPlaceholder(ptb, 'description') : undefined
                 }
               />
             )}
-            {ptb?.category === 'product_name' && (
+            {category === 'product_name' && (
               <Select
-                label={t(`${ptb?.category}.type`)}
+                label={t(`${category}.type`)}
                 selectedKeys={[type ?? '']}
                 onChange={(e) => {
                   if (!e.target.value) {
@@ -68,7 +77,7 @@ export function PTBEditForm({ ptb, onSave }: PTBEditFormProps) {
                   }
                   setType(e.target.value as TProductTreeBranchProductType)
                 }}
-                isDisabled={!ptb || checkReadOnly(ptb, 'type')}
+                isDisabled={ptb ? checkReadOnly(ptb, 'type') : false}
                 placeholder={ptb ? getPlaceholder(ptb, 'type') : undefined}
               >
                 {hasSoftware ? (
@@ -87,9 +96,12 @@ export function PTBEditForm({ ptb, onSave }: PTBEditFormProps) {
             <Button
               color="primary"
               onPress={() => {
-                if (ptb) {
-                  onSave?.({ ...ptb, name, description, type })
-                }
+                onSave?.({
+                  ...ptb,
+                  name,
+                  description,
+                  type,
+                } as TProductTreeBranch)
                 onClose()
               }}
             >

--- a/src/routes/products/components/ProductCard.tsx
+++ b/src/routes/products/components/ProductCard.tsx
@@ -2,12 +2,10 @@ import IconButton from '@/components/forms/IconButton'
 import { useProductTreeBranch } from '@/utils/useProductTreeBranch'
 import { faCodeFork } from '@fortawesome/free-solid-svg-icons'
 import { Chip } from '@heroui/chip'
-import { Modal, useDisclosure } from '@heroui/modal'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import { TProductTreeBranch, getPTBName } from '../types/tProductTreeBranch'
 import InfoCard, { InfoCardProps } from './InfoCard'
-import { PTBEditForm } from './PTBEditForm'
 import TagList from './TagList'
 
 export type ProductCardProps = Partial<InfoCardProps> & {
@@ -17,14 +15,11 @@ export type ProductCardProps = Partial<InfoCardProps> & {
 
 export default function ProductCard({
   product,
-  openEditModal,
+  onEdit,
   ...props
 }: ProductCardProps) {
   const { t } = useTranslation()
-  const { updatePTB, deletePTB, findProductTreeBranch } = useProductTreeBranch()
-  const { isOpen, onOpen, onOpenChange } = useDisclosure({
-    defaultOpen: openEditModal,
-  })
+  const { deletePTB, findProductTreeBranch } = useProductTreeBranch()
   const navigate = useNavigate()
 
   return (
@@ -49,7 +44,7 @@ export default function ProductCard({
           onPress={() => navigate(`product/${product.id}`)}
         />
       }
-      onEdit={onOpen}
+      onEdit={onEdit}
       onDelete={() => deletePTB(product.id)}
       {...props}
     >
@@ -65,14 +60,6 @@ export default function ProductCard({
           }
         />
       )}
-      <Modal size="xl" isOpen={isOpen} onOpenChange={onOpenChange}>
-        <PTBEditForm
-          ptb={product}
-          onSave={(ptb) => {
-            updatePTB(ptb)
-          }}
-        />
-      </Modal>
     </InfoCard>
   )
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
If the user presses on an add button the Creation Modal opens, but no entry is created yet, this only happens if the user clicks on the "Save"-Button. This change in the logic also caused some rearrangement for the buttons.
The german word for Vendor is renamed from "Anbieter" to "Hersteller"

TLP-Url is removed from the UI

## Related Tickets & Documents

- Closes #126 
- Closes #113 


<img width="1151" height="517" alt="Screenshot 2025-07-29 at 11 13 34" src="https://github.com/user-attachments/assets/4b262382-6c7d-44f0-a5b7-a3f82383e5eb" />
