### PR TITLE
fix terminal and tailwind warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,10 +1,10 @@
-import reactPlugin from 'eslint-plugin-react'
-import reactHooksPlugin from 'eslint-plugin-react-hooks'
-import prettierPlugin from 'eslint-plugin-prettier'
 import typescriptEslint from '@typescript-eslint/eslint-plugin'
 import typescriptParser from '@typescript-eslint/parser'
-import reactRefreshPlugin from 'eslint-plugin-react-refresh'
 import importPlugin from 'eslint-plugin-import'
+import prettierPlugin from 'eslint-plugin-prettier'
+import reactPlugin from 'eslint-plugin-react'
+import reactHooksPlugin from 'eslint-plugin-react-hooks'
+import reactRefreshPlugin from 'eslint-plugin-react-refresh'
 import tailwind from 'eslint-plugin-tailwindcss'
 
 export default [
@@ -61,5 +61,15 @@ export default [
       },
     },
   },
-  ...tailwind.configs['flat/recommended'],
+  {
+    files: ['**/*.{js,jsx,ts,tsx}'],
+    plugins: {
+      tailwindcss: tailwind,
+    },
+    rules: {
+      ...tailwind.configs['flat/recommended'][0].rules,
+      // Disable the no-custom-classname rule since you're using HeroUI theme tokens
+      'tailwindcss/no-custom-classname': 'off',
+    },
+  },
 ]

--- a/src/routes/document-information/Acknowledgments.tsx
+++ b/src/routes/document-information/Acknowledgments.tsx
@@ -50,7 +50,7 @@ export default function Acknowledgments() {
       title={t('nav.documentInformation.acknowledgments')}
       progress={1.8}
       onBack={'/document-information/references'}
-      onContinue="/product-families"
+      onContinue="/products/families"
     >
       {listValidation.isTouched && listValidation.hasErrors && (
         <Alert color="danger">

--- a/src/routes/products/ProductManagement.tsx
+++ b/src/routes/products/ProductManagement.tsx
@@ -25,7 +25,7 @@ export default function ProductManagement() {
   return (
     <WizardStep
       progress={2.5}
-      onBack={'/product-families'}
+      onBack={'/products/families'}
       onContinue={'/vulnerabilities'}
       noContentWrapper
     >

--- a/src/routes/shared/NotesList.tsx
+++ b/src/routes/shared/NotesList.tsx
@@ -22,7 +22,7 @@ export const noteCategories = [
   'legal_disclaimer',
   'other',
   'summary',
-] as const
+]
 
 export type TNoteCategory = (typeof noteCategories)[number]
 

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -9,7 +9,7 @@ import {
 } from '@/routes/products/types/tProductTreeBranch'
 import { TRelationship } from '@/routes/products/types/tRelationship'
 import { TVulnerability } from '@/routes/vulnerabilities/types/tVulnerability'
-import { useEffect } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useConfigStore } from './useConfigStore'
 import useDocumentStore from './useDocumentStore'
 import { UpdatePriority, useStateInitializer } from './useStateInitializer'
@@ -162,16 +162,7 @@ export function useTemplateInitializer() {
   )
   const { getTemplateValue, getTemplateData } = useTemplate()
 
-  // apply template to document state
-  useEffect(() => {
-    if (config) {
-      initialize(UpdatePriority.Low, () => {
-        initializeTemplateData()
-      })
-    }
-  }, [config])
-
-  function initializeTemplateData() {
+  const initializeTemplateData = useCallback(() => {
     const documentInformation = getTemplateData(
       getDocumentInformationTemplateKeys(),
       getDefaultDocumentInformation(),
@@ -188,7 +179,24 @@ export function useTemplateInitializer() {
     updateVulnerabilities(
       getTemplateValue<TVulnerability[]>('vulnerabilities', []),
     )
-  }
+  }, [
+    getTemplateData,
+    updateDocumentInformation,
+    updateProducts,
+    getTemplateValue,
+    updateFamilies,
+    updateRelationships,
+    updateVulnerabilities,
+  ])
+
+  // apply template to document state
+  useEffect(() => {
+    if (config) {
+      initialize(UpdatePriority.Low, () => {
+        initializeTemplateData()
+      })
+    }
+  }, [config, initialize, initializeTemplateData])
 
   return { initializeTemplateData }
 }

--- a/tests/routes/document-information/Acknowledgments.test.tsx
+++ b/tests/routes/document-information/Acknowledgments.test.tsx
@@ -371,7 +371,7 @@ describe('Acknowledgments', () => {
       )
       expect(screen.getByTestId('continue-link')).toHaveAttribute(
         'href',
-        '/product-families',
+        '/products/families',
       )
       expect(screen.getByTestId('component-list')).toBeInTheDocument()
       expect(container.firstChild).toMatchSnapshot()

--- a/tests/routes/document-information/__snapshots__/Acknowledgments.test.tsx.snap
+++ b/tests/routes/document-information/__snapshots__/Acknowledgments.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`Acknowledgments > Component Rendering > should render with empty acknow
     </a>
     <a
       data-testid="continue-link"
-      href="/product-families"
+      href="/products/families"
     >
       Continue
     </a>

--- a/tests/routes/products/ProductManagement.test.tsx
+++ b/tests/routes/products/ProductManagement.test.tsx
@@ -188,7 +188,7 @@ describe('ProductManagement', () => {
 
       const wizardStep = screen.getByTestId('wizard-step')
       expect(wizardStep).toHaveAttribute('data-progress', '2.5')
-      expect(wizardStep).toHaveAttribute('data-on-back', '/product-families')
+      expect(wizardStep).toHaveAttribute('data-on-back', '/products/families')
       expect(wizardStep).toHaveAttribute('data-on-continue', '/vulnerabilities')
       expect(wizardStep).toHaveAttribute('data-no-content-wrapper', 'true')
     })


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
- Custom Classnames are not presented as warnings in the terminal anymore because they are allowed now
- The navigation through product management got fixed
- Dependency Warning for the template was resolved
