### PR TITLE
intuitive navigation through vulnerabilities

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -13,8 +13,8 @@
       "search": "Suchen",
       "save": "Speichern",
       "close": "Schließen",
-      "back": "Zurück",
-      "next": "Weiter",
+      "back": "Vorheriger Schritt",
+      "next": "Nächster Schritt",
       "ok": "OK",
       "untitled": "Unbenannt",
       "add": "{{label}} hinzufügen",
@@ -207,6 +207,10 @@
       "flags": "Kennzeichnungen",
       "flag": {
         "title": "Kennzeichnung"
+      },
+      "navigation": {
+        "backTo": "Zurück zu {{tabName}}",
+        "continueTo": "Weiter zu {{tabName}}"
       }
     },
     "notes": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -13,8 +13,8 @@
       "search": "Search",
       "save": "Save",
       "close": "Close",
-      "back": "Back",
-      "next": "Next",
+      "back": "Previous Step",
+      "next": "Next Step",
       "ok": "OK",
       "untitled": "Untitled",
       "add": "Add {{label}}",
@@ -212,6 +212,10 @@
         "vulnerable_code_cannot_be_controlled_by_adversary": "Vulnerable code cannot be controlled by adversary",
         "vulnerable_code_not_in_execute_path": "Vulnerable code not in execute path",
         "vulnerable_code_not_present": "Vulnerable code not present"
+      },
+      "navigation": {
+        "backTo": "Back to {{tabName}}",
+        "continueTo": "Continue to {{tabName}}"
       }
     },
     "notes": {

--- a/src/components/WizardStep.tsx
+++ b/src/components/WizardStep.tsx
@@ -3,13 +3,17 @@ import { PropsWithChildren } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import ProgressBar from './ProgressBar'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons'
 
 export type WizardStepProps = PropsWithChildren<{
   title?: string
   subtitle?: string
   progress?: number
   onBack?: string | (() => void)
+  backLabel?: string
   onContinue?: string | (() => void)
+  continueLabel?: string
   noContentWrapper?: boolean
 }>
 
@@ -18,7 +22,9 @@ export default function WizardStep({
   subtitle,
   progress,
   onBack,
+  backLabel,
   onContinue,
+  continueLabel,
   children,
   noContentWrapper,
 }: WizardStepProps) {
@@ -37,7 +43,7 @@ export default function WizardStep({
         progress={progress ?? 1}
       />
       {(noContentWrapper && <>{children}</>) || (
-        <div className="border-default-200 bg-content1 border-default-200 flex flex-col gap-2 rounded-lg border p-8">
+        <div className="border-default-200 bg-content1 flex flex-col gap-2 rounded-lg border p-8">
           <div className="gap-2">
             {title && <div className="text-xl font-semibold">{title}</div>}
             {subtitle && (
@@ -47,7 +53,7 @@ export default function WizardStep({
           {children}
         </div>
       )}
-      <div className="flex justify-between">
+      <div className="flex justify-between pt-6">
         <div>
           {onBack !== undefined && (
             <Button
@@ -56,8 +62,9 @@ export default function WizardStep({
               }
               variant="bordered"
               className="bg-content1 border-1"
+              startContent={<FontAwesomeIcon icon={faArrowLeft} />}
             >
-              {t('common.back')}
+              {t(backLabel ?? 'common.back')}
             </Button>
           )}
         </div>
@@ -69,8 +76,9 @@ export default function WizardStep({
                 : onContinue?.()
             }
             color="primary"
+            endContent={<FontAwesomeIcon icon={faArrowRight} />}
           >
-            {t('common.next')}
+            {t(continueLabel ?? 'common.next')}
           </Button>
         )}
       </div>

--- a/src/routes/vulnerabilities/General.tsx
+++ b/src/routes/vulnerabilities/General.tsx
@@ -25,7 +25,7 @@ export default function General({
   const cwes = useMemo<TCwe[]>(() => weaknesses, [])
 
   return (
-    <VSplit>
+    <VSplit className="rounded-lg border border-gray-200 p-4">
       <Input
         label={t('vulnerabilities.general.title')}
         csafPath={`/vulnerabilities/${vulnerabilityIndex}/title`}

--- a/src/routes/vulnerabilities/Notes.tsx
+++ b/src/routes/vulnerabilities/Notes.tsx
@@ -40,7 +40,7 @@ export default function Notes({
   )
 
   return (
-    <VSplit>
+    <VSplit className="rounded-lg border border-gray-200 p-4">
       {(isTouched || listValidation.isTouched) && listValidation.hasErrors && (
         <Alert color="danger">
           {listValidation.errorMessages.map((m) => (

--- a/src/routes/vulnerabilities/Products.tsx
+++ b/src/routes/vulnerabilities/Products.tsx
@@ -48,7 +48,7 @@ export default function Products({
   })
 
   return (
-    <VSplit className="gap-2">
+    <VSplit className="gap-2 rounded-lg border border-gray-200 p-4">
       {validation.hasErrors && (
         <Alert color="danger">
           {validation.errorMessages.map((m) => (

--- a/tests/components/__snapshots__/WizardStep.test.tsx.snap
+++ b/tests/components/__snapshots__/WizardStep.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`WizardStep > should render with progress bar and content 1`] = `
     </span>
   </div>
   <div
-    class="border-default-200 bg-content1 border-default-200 flex flex-col gap-2 rounded-lg border p-8"
+    class="border-default-200 bg-content1 flex flex-col gap-2 rounded-lg border p-8"
   >
     <div
       class="gap-2"
@@ -46,7 +46,7 @@ exports[`WizardStep > should render with progress bar and content 1`] = `
     </div>
   </div>
   <div
-    class="flex justify-between"
+    class="flex justify-between pt-6"
   >
     <div />
   </div>

--- a/tests/utils/csafExport/helpers.test.ts
+++ b/tests/utils/csafExport/helpers.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Unmock the helpers to test the actual implementation
+vi.unmock('../../../src/utils/csafExport/helpers')
+
+import { getFilename } from '../../../src/utils/csafExport/helpers'
+
+describe('getFilename', () => {
+  it('should convert simple tracking ID to lowercase filename', () => {
+    const result = getFilename('SIMPLE-ID')
+    expect(result).toBe('simple-id')
+  })
+
+  it('should replace special characters with underscores', () => {
+    const result = getFilename('ID-with@special#characters%')
+    expect(result).toBe('id-with_special_characters_')
+  })
+
+  it('should preserve valid characters (lowercase, digits, +, -)', () => {
+    const result = getFilename('valid-id+123')
+    expect(result).toBe('valid-id+123')
+  })
+
+  it('should handle empty string', () => {
+    const result = getFilename('')
+    expect(result).toBe('')
+  })
+
+  it('should handle spaces', () => {
+    const result = getFilename('ID with spaces')
+    expect(result).toBe('id_with_spaces')
+  })
+
+  it('should handle multiple consecutive special characters', () => {
+    const result = getFilename('ID!!!@@@###')
+    expect(result).toBe('id_')
+  })
+
+  it('should preserve numbers and valid characters', () => {
+    const result = getFilename('ID-2024-001')
+    expect(result).toBe('id-2024-001')
+  })
+
+  it('should handle dots and slashes', () => {
+    const result = getFilename('ID.with.dots/and/slashes')
+    expect(result).toBe('id_with_dots_and_slashes')
+  })
+
+  it('should handle mixed case alphanumeric with valid characters', () => {
+    const result = getFilename('MyApp-v1.2+build-123')
+    expect(result).toBe('myapp-v1_2+build-123')
+  })
+
+  it('should handle unicode characters by replacing them', () => {
+    const result = getFilename('ID-with-ünïcödë')
+    expect(result).toBe('id-with-_n_c_d_')
+  })
+})

--- a/tests/utils/useDocumentStore.test.ts
+++ b/tests/utils/useDocumentStore.test.ts
@@ -1,0 +1,258 @@
+ import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// Unmock the store to test actual implementation
+vi.unmock('../../src/utils/useDocumentStore')
+
+import useDocumentStore from '../../src/utils/useDocumentStore'
+import { getDefaultDocumentInformation } from '../../src/routes/document-information/types/tDocumentInformation'
+
+describe('useDocumentStore', () => {
+  beforeEach(() => {
+    // Reset store before each test
+    const { result } = renderHook(() => useDocumentStore())
+    act(() => {
+      result.current.reset()
+    })
+  })
+
+  it('should initialize with default values', () => {
+    const { result } = renderHook(() => useDocumentStore())
+    
+    expect(result.current.documentInformation).toEqual(getDefaultDocumentInformation())
+    expect(result.current.products).toEqual([])
+    expect(result.current.families).toEqual([])
+    expect(result.current.relationships).toEqual([])
+    expect(result.current.vulnerabilities).toEqual([])
+    expect(result.current.importedCSAFDocument).toEqual({})
+  })
+
+  it('should update document information', () => {
+    const { result } = renderHook(() => useDocumentStore())
+    const newDocInfo = {
+      ...getDefaultDocumentInformation(),
+      title: 'Test Document',
+    }
+
+    act(() => {
+      result.current.updateDocumentInformation(newDocInfo)
+    })
+
+    expect(result.current.documentInformation.title).toBe('Test Document')
+  })
+
+  it('should update products', () => {
+    const { result } = renderHook(() => useDocumentStore())
+    const mockProducts = [
+      {
+        id: '1',
+        name: 'Test Product',
+        description: 'A test product',
+        type: 'software' as const,
+        vendor: { id: '1', name: 'Test Vendor', description: '' },
+        versions: [],
+        relationships: [],
+      },
+    ]
+
+    act(() => {
+      result.current.updateProducts(mockProducts)
+    })
+
+    expect(result.current.products).toEqual(mockProducts)
+  })
+
+  it('should update families', () => {
+    const { result } = renderHook(() => useDocumentStore())
+    const mockFamilies = [
+      {
+        id: '1',
+        name: 'Test Family',
+        description: 'A test family',
+        parent: undefined,
+      },
+    ]
+
+    act(() => {
+      result.current.updateFamilies(mockFamilies)
+    })
+
+    expect(result.current.families).toEqual(mockFamilies)
+  })
+
+  it('should update relationships', () => {
+    const { result } = renderHook(() => useDocumentStore())
+    const mockRelationships = [
+      {
+        id: '1',
+        name: 'Test Relationship',
+        sourceProductId: 'source-1',
+        targetProductId: 'target-1',
+        sourceVersionIds: [],
+        targetVersionIds: [],
+        category: 'default_component_of' as const,
+      },
+    ]
+
+    act(() => {
+      result.current.updateRelationships(mockRelationships)
+    })
+
+    expect(result.current.relationships).toEqual(mockRelationships)
+  })
+
+  it('should update vulnerabilities', () => {
+    const { result } = renderHook(() => useDocumentStore())
+    const mockVulnerabilities = [
+      {
+        id: '1',
+        title: 'Test Vulnerability',
+        cve: 'CVE-2024-0001',
+        notes: [],
+        products: [],
+        remediations: [],
+        scores: [],
+        flags: [],
+      },
+    ]
+
+    act(() => {
+      result.current.updateVulnerabilities(mockVulnerabilities)
+    })
+
+    expect(result.current.vulnerabilities).toEqual(mockVulnerabilities)
+  })
+
+  it('should set imported CSAF document', () => {
+    const { result } = renderHook(() => useDocumentStore())
+    const mockDocument = {
+      document: {
+        title: 'Imported Document',
+      },
+    }
+
+    act(() => {
+      result.current.setImportedCSAFDocument(mockDocument)
+    })
+
+    expect(result.current.importedCSAFDocument).toEqual(mockDocument)
+  })
+
+  it('should merge imported CSAF document with existing data', () => {
+    const { result } = renderHook(() => useDocumentStore())
+    const firstUpdate = {
+      document: {
+        title: 'First Title',
+      },
+    }
+    const secondUpdate = {
+      document: {
+        category: 'csaf_security_advisory',
+      },
+    }
+
+    act(() => {
+      result.current.setImportedCSAFDocument(firstUpdate)
+    })
+
+    act(() => {
+      result.current.setImportedCSAFDocument(secondUpdate)
+    })
+
+    // The merge replaces properties at the same level, not deep merge
+    expect(result.current.importedCSAFDocument).toEqual({
+      document: {
+        category: 'csaf_security_advisory',
+      },
+    })
+  })
+
+  it('should reset all data', () => {
+    const { result } = renderHook(() => useDocumentStore())
+    
+    // First set some data
+    act(() => {
+      result.current.updateProducts([
+        {
+          id: '1',
+          name: 'Test Product',
+          description: 'Test',
+          type: 'software',
+          vendor: { id: '1', name: 'Test Vendor', description: '' },
+          versions: [],
+          relationships: [],
+        },
+      ])
+      result.current.setImportedCSAFDocument({ 
+        document: { 
+          title: 'Test Import Data' 
+        } 
+      } as any)
+    })
+
+    // Verify data is set
+    expect(result.current.products).toHaveLength(1)
+    // Note: importedCSAFDocument might have other data merged in, so just check for our test data
+    expect(result.current.importedCSAFDocument).toMatchObject({ 
+      document: { 
+        title: 'Test Import Data' 
+      } 
+    })
+
+    // Reset
+    act(() => {
+      result.current.reset()
+    })
+
+    // Verify reset - only the main document data gets reset, not importedCSAFDocument
+    expect(result.current.documentInformation).toEqual(getDefaultDocumentInformation())
+    expect(result.current.products).toEqual([])
+    expect(result.current.families).toEqual([])
+    expect(result.current.relationships).toEqual([])
+    expect(result.current.vulnerabilities).toEqual([])
+    // importedCSAFDocument is not reset by the reset function
+    expect(result.current.importedCSAFDocument).toMatchObject({ 
+      document: { 
+        title: 'Test Import Data' 
+      } 
+    })
+  })
+
+  it('should maintain state consistency across multiple updates', () => {
+    const { result } = renderHook(() => useDocumentStore())
+    
+    act(() => {
+      result.current.updateProducts([
+        {
+          id: '1',
+          name: 'Product 1',
+          description: 'First product',
+          type: 'software',
+          vendor: { id: '1', name: 'Vendor 1', description: '' },
+          versions: [],
+          relationships: [],
+        },
+      ])
+    })
+
+    act(() => {
+      result.current.updateVulnerabilities([
+        {
+          id: '1',
+          title: 'Vulnerability 1',
+          cve: 'CVE-2024-0001',
+          notes: [],
+          products: [],
+          remediations: [],
+          scores: [],
+          flags: [],
+        },
+      ])
+    })
+
+    expect(result.current.products).toHaveLength(1)
+    expect(result.current.vulnerabilities).toHaveLength(1)
+    expect(result.current.families).toHaveLength(0)
+    expect(result.current.relationships).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description

Within a vulnerability switching a tab wasn't intuitive. The overall navigation between steps got improved and within a vulnerability the user now can also use forward and backward navigation buttons to switch the tabs.

## Changes
- Added Icons and changed Label for the overall navigation, to highlight the navigation between sections
- New Navigation Buttons within a vulnerability to switch between tabs

## Related Tickets & Documents

- Closes #176
