### PR TITLE
feat: Implement form for `/document/tracking/aliases`

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -115,6 +115,27 @@ The following suffixes can be appended to most fields to enhance configurability
 
 ---
 
+### Aliases
+
+**Path:** `document-information.aliases[]`
+
+A list of alternative identifiers for the document.
+
+**Example Structure:**
+```json
+{
+  "document-information": {
+    "aliases": [
+      "legacy-doc-id-2023",
+      "VULN-2024-001",
+      "SA-2024-002"
+    ]
+  }
+}
+```
+
+---
+
 ## Product Families
 
 **Path:** `product_families[]`

--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -37,6 +37,12 @@
           "type": "string",
           "enum": ["en", "de"]
         },
+        "document-information.aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
 
         "document-information.tlp.label": {
           "type": "string",

--- a/docs/io.github.sec-o-simple.example.json
+++ b/docs/io.github.sec-o-simple.example.json
@@ -70,6 +70,10 @@
       }
     ],
 
+    "document-information.aliases": [
+      "example-alias"
+    ],
+
     "product_families": [
       {
         "id": "family1",

--- a/locales/de.json
+++ b/locales/de.json
@@ -50,6 +50,7 @@
         "notes": "Notizen",
         "publisher": "Herausgeber",
         "references": "Referenzen",
+        "aliases": "Aliase",
         "acknowledgments": "Danksagungen"
       },
       "tracking": "Historie"
@@ -86,6 +87,7 @@
           "label.placeholder": "TLP-Label auswählen",
           "url": "TLP-URL"
         },
+        "alias": "Alias",
         "language": "Sprache",
         "languages": {
           "de": "Deutsch",

--- a/locales/en.json
+++ b/locales/en.json
@@ -50,7 +50,8 @@
         "notes": "Notes",
         "publisher": "Publisher",
         "references": "References",
-        "acknowledgments": "Acknowledgements"
+        "acknowledgments": "Acknowledgements",
+        "aliases": "Aliases"
       },
       "tracking": "History"
     },
@@ -86,6 +87,7 @@
           "label.placeholder": "Select TLP label",
           "url": "TLP-URL"
         },
+        "alias": "Alias",
         "language": "Language",
         "languages": {
           "de": "German",

--- a/package-lock.json
+++ b/package-lock.json
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.9.tgz",
-      "integrity": "sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.10.tgz",
+      "integrity": "sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -349,7 +349,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "6.14.0",
+        "qs": "~6.14.1",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^5.0.0",
         "tunnel-agent": "^0.6.0",
@@ -1004,15 +1004,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
@@ -4749,9 +4740,9 @@
       "license": "MIT"
     },
     "node_modules/@secvisogram/csaf-validator-lib": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@secvisogram/csaf-validator-lib/-/csaf-validator-lib-2.0.10.tgz",
-      "integrity": "sha512-dYwhLD6V3/R/noEYoBMQz+74Tyw5Zc/YSUOjgAtFj+9TPYDMFaBCf/lPEUYmqrVKGjGf9aSgMOhp2+9d+vyy0Q==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@secvisogram/csaf-validator-lib/-/csaf-validator-lib-2.0.17.tgz",
+      "integrity": "sha512-sKgJrLuSOQewTwE9zzCrU49B1fh85EDdIEhFJhxQ/LoMdNfcFWhOAvJBTXrWx+NfeDX3VSjCFpKG6U9Hq8sAfw==",
       "license": "MIT",
       "dependencies": {
         "@js-joda/core": "^5.6.1",
@@ -4765,7 +4756,7 @@
         "packageurl-js": "^2.0.1",
         "semver": "^7.5.4",
         "temporal-polyfill": "^0.3.0",
-        "undici": "^5.27.0"
+        "undici": "^6.23.0"
       }
     },
     "node_modules/@swc/core": {
@@ -7189,14 +7180,14 @@
       "license": "0BSD"
     },
     "node_modules/cypress": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.3.0.tgz",
-      "integrity": "sha512-g9rDhoK9y8wW4Vx3Ppr8dtfvThXxPL3mJsV5e98fG+6EerrhXKmeRT2sL86cvNRtEZouXJfsuVL1lqiMuGNGcg==",
+      "version": "15.10.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.10.0.tgz",
+      "integrity": "sha512-OtUh7OMrfEjKoXydlAD1CfG2BvKxIqgWGY4/RMjrqQ3BKGBo5JFKoYNH+Tpcj4xKxWH4XK0Xri+9y8WkxhYbqQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@cypress/request": "^3.0.9",
+        "@cypress/request": "^3.0.10",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -7224,7 +7215,7 @@
         "hasha": "5.2.2",
         "is-installed-globally": "~0.4.0",
         "listr2": "^3.8.3",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.8",
         "ospath": "^1.2.2",
@@ -7232,9 +7223,8 @@
         "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.7.1",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -11718,9 +11708,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -11839,9 +11829,9 @@
       "peer": true
     },
     "node_modules/react-router": {
-      "version": "7.9.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.3.tgz",
-      "integrity": "sha512-4o2iWCFIwhI/eYAIL43+cjORXYn/aRQPgtFRRZb3VzoyQ5Uej0Bmqj7437L97N9NJW4wnicSwLOLS+yCXfAPgg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
+      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -12772,9 +12762,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.0.tgz",
+      "integrity": "sha512-z5pjzvC8UnQJ/iu34z+mo3lAeMzTGdArjPQoG5uPyV5XY4BY+M6ZcRTl4XnZqudz6sP713LhWMKv6e0kGFGCgQ==",
       "dev": true,
       "license": "MIT",
       "os": [
@@ -12865,10 +12855,10 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
-      "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
-      "license": "ISC",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -13337,15 +13327,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import General from './routes/document-information/General'
 import Notes from './routes/document-information/Notes'
 import Publisher from './routes/document-information/Publisher'
 import References from './routes/document-information/References'
+import Aliases from './routes/document-information/Aliases'
 import Tracking from './routes/document-information/Tracking'
 import DocumentSelection from './routes/document-selection/DocumentSelection'
 import Product from './routes/products/Product'
@@ -32,6 +33,7 @@ export default function App() {
               <Route path="notes" element={<Notes />} />
               <Route path="publisher" element={<Publisher />} />
               <Route path="references" element={<References />} />
+              <Route path="aliases" element={<Aliases />} />
               <Route path="acknowledgments" element={<Acknowledgments />} />
             </Route>
             <Route path="products">

--- a/src/components/layout/NavigationLayout.tsx
+++ b/src/components/layout/NavigationLayout.tsx
@@ -35,6 +35,10 @@ export default function NavigationLayout() {
               to="/document-information/references"
             />
             <SubSection
+              title={t('nav.documentInformation.aliases')}
+              to="/document-information/aliases"
+            />
+            <SubSection
               title={t('nav.documentInformation.acknowledgments')}
               to="/document-information/acknowledgments"
             />

--- a/src/routes/document-information/Acknowledgments.tsx
+++ b/src/routes/document-information/Acknowledgments.tsx
@@ -49,7 +49,7 @@ export default function Acknowledgments() {
     <WizardStep
       title={t('nav.documentInformation.acknowledgments')}
       progress={1.8}
-      onBack={'/document-information/references'}
+      onBack={'/document-information/aliases'}
       onContinue="/products/families"
     >
       {listValidation.isTouched && listValidation.hasErrors && (

--- a/src/routes/document-information/Aliases.tsx
+++ b/src/routes/document-information/Aliases.tsx
@@ -1,0 +1,120 @@
+import StatusIndicator from '@/components/StatusIndicator'
+import WizardStep from '@/components/WizardStep'
+import ComponentList from '@/components/forms/ComponentList'
+import { Input } from '@/components/forms/Input'
+import VSplit from '@/components/forms/VSplit'
+import useDocumentStoreUpdater from '@/utils/useDocumentStoreUpdater'
+import { useListState } from '@/utils/useListState'
+import { useFieldValidation } from '@/utils/validation/useFieldValidation'
+import { useListValidation } from '@/utils/validation/useListValidation'
+import usePageVisit from '@/utils/validation/usePageVisit'
+import useValidationStore from '@/utils/validation/useValidationStore'
+import { Alert } from '@heroui/react'
+import { useTranslation } from 'react-i18next'
+import { uid } from 'uid'
+import { TDocumentInformation } from './types/tDocumentInformation'
+
+type AliasWrapper = {
+  id: string
+  alias: string
+}
+
+export default function Aliases() {
+  const aliasesListState = useListState<AliasWrapper>({
+    generator: () => ({ id: uid(), alias: '' }),
+  })
+
+  const { t } = useTranslation()
+  usePageVisit()
+
+  useDocumentStoreUpdater<TDocumentInformation>({
+    localState: [
+      aliasesListState.data,
+      () => ({
+        aliases: aliasesListState.data.map((wrapper) => wrapper.alias),
+      }),
+    ],
+    valueField: 'documentInformation',
+    valueUpdater: 'updateDocumentInformation',
+    init: (initialData) =>
+      aliasesListState.setData(
+        initialData.aliases?.map((alias) => ({ id: uid(), alias })) ?? [],
+      ),
+  })
+
+  const listValidation = useListValidation(
+    '/document/tracking/aliases',
+    aliasesListState.data,
+  )
+
+  return (
+    <WizardStep
+      title={t('nav.documentInformation.aliases')}
+      progress={1.7}
+      onBack={'/document-information/references'}
+      onContinue="/document-information/acknowledgments"
+    >
+      {listValidation.isTouched && listValidation.hasErrors && (
+        <Alert color="danger">
+          {listValidation.errorMessages.map((m) => (
+            <p key={m.path}>{m.message}</p>
+          ))}
+        </Alert>
+      )}
+      <ComponentList
+        listState={aliasesListState}
+        title="alias"
+        itemLabel={t('document.general.alias')}
+        itemBgColor="bg-zinc-50"
+        startContent={StartContent}
+        content={(wrapper, index) => (
+          <AliasForm
+            aliasIndex={index}
+            wrapper={wrapper}
+            onChange={aliasesListState.updateDataEntry}
+          />
+        )}
+      />
+    </WizardStep>
+  )
+}
+
+function StartContent({ index }: { index: number }) {
+  const { hasErrors } = useFieldValidation(
+    `/document/tracking/aliases/${index}`,
+  )
+
+  return <StatusIndicator hasErrors={hasErrors} hasVisited={true} />
+}
+
+function AliasForm({
+  wrapper,
+  aliasIndex,
+  onChange,
+}: {
+  wrapper: AliasWrapper
+  aliasIndex: number
+  onChange: (wrapper: AliasWrapper) => void
+}) {
+  const { t } = useTranslation()
+  const message = useValidationStore((state) => state.messages).filter(
+    (m) => m.path === `/document/aliases/${aliasIndex}`,
+  )?.[0]
+
+  return (
+    <VSplit>
+      {message?.severity === 'error' && (
+        <Alert color="danger" className="mb-4">
+          <p>{message.message}</p>
+        </Alert>
+      )}
+
+      <Input
+        label={t('document.general.alias')}
+        csafPath={`/document/tracking/aliases/${aliasIndex}`}
+        value={wrapper.alias}
+        onValueChange={(val) => onChange({ ...wrapper, alias: val })}
+      />
+    </VSplit>
+  )
+}

--- a/src/routes/document-information/References.tsx
+++ b/src/routes/document-information/References.tsx
@@ -49,7 +49,7 @@ export default function References() {
       title={t('nav.documentInformation.references')}
       progress={1.6}
       onBack={'/document-information/publisher'}
-      onContinue="/document-information/acknowledgments"
+      onContinue="/document-information/aliases"
     >
       {listValidation.isTouched && listValidation.hasErrors && (
         <Alert color="danger">

--- a/src/routes/document-information/types/tDocumentInformation.ts
+++ b/src/routes/document-information/types/tDocumentInformation.ts
@@ -21,6 +21,7 @@ export type TDocumentInformation = TGeneralDocumentInformation & {
   revisionHistory: TRevisionHistoryEntry[]
   acknowledgments: TAcknowledgment[]
   notes: TNote[]
+  aliases: string[]
   references: TDocumentReference[]
 }
 
@@ -31,6 +32,7 @@ export function getDefaultDocumentInformation(): TDocumentInformation {
     acknowledgments: [],
     notes: [],
     references: [],
+    aliases: [],
     revisionHistory: [
       {
         id: uid(),
@@ -54,5 +56,6 @@ export function getDocumentInformationTemplateKeys(): TemplateKeys<TDocumentInfo
     references: 'document-information.references',
     revisionHistory: 'document-information.revision-history',
     acknowledgments: 'document-information.acknowledgments',
+    aliases: 'document-information.aliases',
   }
 }

--- a/src/utils/csafExport/csafExport.ts
+++ b/src/utils/csafExport/csafExport.ts
@@ -91,6 +91,9 @@ export function createCSAFDocument(
           number: entry.number,
           summary: entry.summary,
         })),
+        aliases: documentInformation.aliases?.length
+          ? documentInformation.aliases
+          : undefined,
         status: documentStore.documentInformation.status,
         version: documentStore.documentInformation.revisionHistory.length
           ? retrieveLatestVersion(

--- a/src/utils/csafImport/csafImport.ts
+++ b/src/utils/csafImport/csafImport.ts
@@ -153,6 +153,10 @@ export function parseCSAFDocument(
         number: revision?.number ?? defaultRevisionHistoryEntry.number,
         summary: revision?.summary ?? defaultRevisionHistoryEntry.summary,
       })) ?? defaultDocumentInformation.revisionHistory,
+    aliases:
+      csafDoc?.tracking?.aliases?.filter(
+        (alias): alias is string => alias !== undefined,
+      ) ?? defaultDocumentInformation.aliases,
     publisher: {
       name:
         csafDoc?.publisher?.name ?? defaultDocumentInformation.publisher.name,

--- a/src/utils/csafImport/scheme.ts
+++ b/src/utils/csafImport/scheme.ts
@@ -44,6 +44,7 @@ export default {
       version: 'string',
       current_release_date: 'string',
       initial_release_date: 'string',
+      aliases: ['string'],
       generator: {
         date: 'string',
         engine: {

--- a/src/utils/validation/usePathValidation.ts
+++ b/src/utils/validation/usePathValidation.ts
@@ -22,6 +22,11 @@ const validationSections: Record<string, HasErrorFunction> = {
   '/document-information/publisher': (errorPaths) => {
     return errorPaths.some((path) => path.startsWith('/document/publisher'))
   },
+  '/document-information/aliases': (errorPaths) => {
+    return errorPaths.some((path) =>
+      path.startsWith('/document/tracking/aliases'),
+    )
+  },
   '/document-information/acknowledgments': (errorPaths) => {
     return errorPaths.some((path) =>
       path.startsWith('/document/acknowledgments'),

--- a/tests/components/layout/NavigationLayout.test.tsx
+++ b/tests/components/layout/NavigationLayout.test.tsx
@@ -85,7 +85,7 @@ describe('NavigationLayout', () => {
     render(<NavigationLayout />)
 
     const statusIndicators = screen.getAllByTestId('status-indicator')
-    expect(statusIndicators).toHaveLength(9) // 5 document info subsections + 2 product management subsections + 1 vulnerabilities main + 1 tracking main
+    expect(statusIndicators).toHaveLength(10) // 6 document info subsections + 2 product management subsections + 1 vulnerabilities main + 1 tracking main
   })
 
   it('should render navigation links', () => {

--- a/tests/routes/document-information/Acknowledgments.test.tsx
+++ b/tests/routes/document-information/Acknowledgments.test.tsx
@@ -367,7 +367,7 @@ describe('Acknowledgments', () => {
       )
       expect(screen.getByTestId('back-link')).toHaveAttribute(
         'href',
-        '/document-information/references',
+        '/document-information/aliases',
       )
       expect(screen.getByTestId('continue-link')).toHaveAttribute(
         'href',

--- a/tests/routes/document-information/Aliases.test.tsx
+++ b/tests/routes/document-information/Aliases.test.tsx
@@ -1,0 +1,223 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Unmock the Aliases component to test the actual implementation
+vi.unmock('../../../src/routes/document-information/Aliases')
+
+import Aliases from '../../../src/routes/document-information/Aliases'
+
+// Add jest-dom matchers
+import '@testing-library/jest-dom'
+
+// Mock all the dependencies
+vi.mock('@/components/StatusIndicator', () => ({
+  default: ({
+    hasErrors,
+    hasVisited,
+  }: {
+    hasErrors: boolean
+    hasVisited: boolean
+  }) => (
+    <div
+      data-testid="status-indicator"
+      data-has-errors={hasErrors}
+      data-has-visited={hasVisited}
+    >
+      Status Indicator
+    </div>
+  ),
+}))
+
+vi.mock('@/components/WizardStep', () => ({
+  default: ({
+    title,
+    progress,
+    onBack,
+    onContinue,
+    children,
+  }: {
+    title: string
+    progress: number
+    onBack: string
+    onContinue: string
+    children: React.ReactNode
+  }) => (
+    <div data-testid="wizard-step">
+      <h1 data-testid="wizard-title">{title}</h1>
+      <div data-testid="progress" data-progress={progress}></div>
+      <div data-testid="navigation">
+        <a href={onBack} data-testid="back-link">
+          Back
+        </a>
+        <a href={onContinue} data-testid="continue-link">
+          Continue
+        </a>
+      </div>
+      <div data-testid="wizard-content">{children}</div>
+    </div>
+  ),
+}))
+
+vi.mock('@/components/forms/ComponentList', () => ({
+  default: ({
+    listState,
+    title,
+    itemLabel,
+    itemBgColor,
+    startContent: StartContent,
+    content,
+  }: {
+    listState: any
+    title: string
+    itemLabel: string
+    itemBgColor: string
+    startContent: React.ComponentType<{ index: number }>
+    content: (item: any, index: number) => React.ReactNode
+  }) => (
+    <div data-testid="component-list">
+      <div data-testid="list-title">{title}</div>
+      <div data-testid="item-label">{itemLabel}</div>
+      <div data-testid="item-bg-color">{itemBgColor}</div>
+      <button data-testid="add-item" onClick={() => listState.addDataEntry()}>
+        Add Item
+      </button>
+      {listState.data.map((item: any, index: number) => (
+        <div key={item.id} data-testid={`list-item-${index}`}>
+          <div data-testid={`start-content-${index}`}>
+            <StartContent index={index} />
+          </div>
+          <div data-testid={`item-content-${index}`}>
+            {content(item, index)}
+          </div>
+          <button
+            data-testid={`remove-item-${index}`}
+            onClick={() => listState.removeDataEntry(item)}
+          >
+            Remove Item
+          </button>
+        </div>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/forms/Input', () => ({
+  Input: ({
+    label,
+    value,
+    onValueChange,
+    csafPath,
+    isDisabled,
+    placeholder,
+  }: any) => (
+    <div data-testid="input-wrapper">
+      <label>{label}</label>
+      <input
+        data-testid="input"
+        data-csaf-path={csafPath}
+        value={value}
+        onChange={(e) => onValueChange(e.target.value)}
+        disabled={isDisabled}
+        placeholder={placeholder}
+      />
+    </div>
+  ),
+}))
+
+vi.mock('@/components/forms/VSplit', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="vsplit">{children}</div>
+  ),
+}))
+
+vi.mock('@/utils/useDocumentStoreUpdater', () => ({
+  default: ({ localState, init }: any) => {
+    // Mock implementation for testing initialization
+    // const [data, setData] = localState
+    // We can simulate initialization if needed, but integration test is better
+    return null
+  },
+}))
+
+vi.mock('@/utils/validation/usePageVisit', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('@/utils/validation/useValidationStore', () => ({
+  default: vi.fn((selector) => selector({ messages: [], markFieldAsTouched: vi.fn() })),
+}))
+
+vi.mock('@/utils/validation/useFieldValidation', () => ({
+  useFieldValidation: vi.fn(() => ({
+    messages: [],
+    hasErrors: false,
+  })),
+}))
+
+vi.mock('@/utils/validation/useListValidation', () => ({
+  useListValidation: vi.fn(() => ({
+    isTouched: false,
+    hasErrors: false,
+    errorMessages: [],
+  })),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+describe('Aliases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders correctly', () => {
+    render(<Aliases />)
+    expect(screen.getByTestId('wizard-title')).toHaveTextContent('nav.documentInformation.aliases')
+    expect(screen.getByTestId('component-list')).toBeInTheDocument()
+    expect(screen.getByTestId('list-title')).toHaveTextContent('alias')
+    expect(screen.getByTestId('item-label')).toHaveTextContent('document.general.alias')
+  })
+
+  it('allows adding an alias', async () => {
+    render(<Aliases />)
+    const user = userEvent.setup()
+
+    const addButton = screen.getByTestId('add-item')
+    await user.click(addButton)
+
+    expect(screen.getByTestId('list-item-0')).toBeInTheDocument()
+    expect(screen.getByTestId('input')).toBeInTheDocument()
+  })
+
+  it('allows editing an alias', async () => {
+    render(<Aliases />)
+    const user = userEvent.setup()
+
+    const addButton = screen.getByTestId('add-item')
+    await user.click(addButton)
+
+    const input = screen.getByTestId('input')
+    await user.type(input, 'New Alias')
+
+    expect(input).toHaveValue('New Alias')
+  })
+
+  it('allows removing an alias', async () => {
+    render(<Aliases />)
+    const user = userEvent.setup()
+
+    const addButton = screen.getByTestId('add-item')
+    await user.click(addButton)
+    
+    expect(screen.getByTestId('list-item-0')).toBeInTheDocument()
+
+    const removeButton = screen.getByTestId('remove-item-0')
+    await user.click(removeButton)
+
+    expect(screen.queryByTestId('list-item-0')).not.toBeInTheDocument()
+  })
+})

--- a/tests/routes/document-information/References.test.tsx
+++ b/tests/routes/document-information/References.test.tsx
@@ -385,7 +385,7 @@ describe('References', () => {
       )
       expect(screen.getByTestId('continue-link')).toHaveAttribute(
         'href',
-        '/document-information/acknowledgments',
+        '/document-information/aliases',
       )
     })
 

--- a/tests/routes/document-information/__snapshots__/Acknowledgments.test.tsx.snap
+++ b/tests/routes/document-information/__snapshots__/Acknowledgments.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Acknowledgments > Component Rendering > should render with empty acknow
   >
     <a
       data-testid="back-link"
-      href="/document-information/references"
+      href="/document-information/aliases"
     >
       Back
     </a>

--- a/tests/utils/csafExport/__snapshots__/csafExport.test.ts.snap
+++ b/tests/utils/csafExport/__snapshots__/csafExport.test.ts.snap
@@ -53,6 +53,7 @@ exports[`csafExport > should create a CSAF document with complete data 1`] = `
     ],
     "title": "Test Security Advisory",
     "tracking": {
+      "aliases": undefined,
       "current_release_date": "2023-02-01T00:00:00.000Z",
       "generator": {
         "date": "2023-07-31T12:00:00.000Z",
@@ -201,6 +202,7 @@ exports[`csafExport > should create a CSAF document with minimal data 1`] = `
     "references": undefined,
     "title": "Test Security Advisory",
     "tracking": {
+      "aliases": undefined,
       "current_release_date": "2023-07-31T12:00:00.000Z",
       "generator": {
         "date": "2023-07-31T12:00:00.000Z",
@@ -277,6 +279,7 @@ exports[`csafExport > should handle vulnerabilities without optional fields 1`] 
     ],
     "title": "Test Security Advisory",
     "tracking": {
+      "aliases": undefined,
       "current_release_date": "2023-02-01T00:00:00.000Z",
       "generator": {
         "date": "2023-07-31T12:00:00.000Z",

--- a/tests/utils/csafImport/__snapshots__/csafImport.test.ts.snap
+++ b/tests/utils/csafImport/__snapshots__/csafImport.test.ts.snap
@@ -4,6 +4,7 @@ exports[`csafImport > parseCSAFDocument > should handle empty/undefined fields g
 {
   "documentInformation": {
     "acknowledgments": [],
+    "aliases": undefined,
     "id": "PARTIAL-001",
     "lang": "de",
     "notes": [],
@@ -60,6 +61,10 @@ exports[`csafImport > parseCSAFDocument > should parse a complete CSAF document 
         "summary": "Reported through bug bounty",
         "url": "https://example.com/bounty",
       },
+    ],
+    "aliases": [
+      "CVE-2023-1234",
+      "AL2023-001",
     ],
     "id": "TEST-2023-001",
     "lang": "en",
@@ -131,6 +136,7 @@ exports[`csafImport > parseCSAFDocument > should parse a minimal CSAF document a
 {
   "documentInformation": {
     "acknowledgments": [],
+    "aliases": undefined,
     "id": "MINIMAL-001",
     "lang": "en",
     "notes": [],

--- a/tests/utils/csafImport/csafImport.test.ts
+++ b/tests/utils/csafImport/csafImport.test.ts
@@ -124,6 +124,7 @@ describe('csafImport', () => {
           tracking: {
             id: 'TEST-2023-001',
             status: 'final',
+            aliases: ['CVE-2023-1234', 'AL2023-001'],
             revision_history: [
               {
                 date: '2023-01-01T00:00:00.000Z',


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description

This PR implements a new subsection called Aliases within the Document Information wizard step. This feature allows users to provide alternative names or identifiers for the document, similar to how the "References" section functions.

## Changes
- Created new route `/document-information/aliases`
- Implemented a list interface allowing users to add, edit, and remove multiple alias strings (including validation)
- Added template support for aliases
- Mapped the input data to the CSAF standard path `/document/tracking/aliases` for import and export of CSAF documents
- Added unit tests to verify rendering, adding, editing, and deleting items.

## How it works
1. Navigate to "Document Information".
2. Locate the "Aliases" subsection.
3. Click "Add Alias" to create a new alias entry.
4. Enter the alias string.
5. Users can add multiple aliases or remove existing ones.

## Related Tickets & Documents
- Closes #170 
