### PR TITLE
feat: Make languages more easily configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Further information about the configuration can be found in the [Configuration](
 
 ### Adding new Languages
 
+> Ensure: That the language code is standardized according to IETF BCP 47 / RFC 5646. Otherwise, the CSAF validator may reject documents with the new language code as invalid.
+> 
 To add a new language to the application:
 
 1. Create a new translation file in the `locales/` directory (e.g., `fr.json`).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
     - [Prerequisites](#prerequisites)
     - [Clone \& Setup](#clone--setup)
     - [Configuration](#configuration)
+    - [Adding new Languages](#adding-new-languages)
     - [Running Locally](#running-locally)
     - [Building for Production](#building-for-production)
   - [Run with Docker](#run-with-docker)
@@ -45,7 +46,18 @@ npm install
 
 ### Configuration
 
-Further information about the configuration can be found in the [Configuration](./docs/CONFIG.md)
+Further information about the configuration can be found in the [Configuration](./docs/CONFIG.md).
+
+### Adding new Languages
+
+To add a new language to the application:
+
+1. Create a new translation file in the `locales/` directory (e.g., `fr.json`).
+2. Import the new locale file in `src/main.tsx`.
+3. Register the new language in the `i18n` initialization object in `src/main.tsx`.
+4. Add the new language name to the existing language files (e.g. `locales/en.json`, `locales/de.json`) under the key `document.general.languages.<language_code>`.
+
+The new language will automatically appear in the document language selection dropdown.
 
 ### Running Locally
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -38,6 +38,7 @@ These texts are used as a prefix to export product descriptions
 |-------------|----------------------------------------|
 | `de` | `Produktbeschreibung für`     |
 | `en` | `Product description for`     |
+| '...' | `...`     |
 
 ---
 

--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -14,11 +14,7 @@
       "properties": {
         "productDescription": {
           "type": "object",
-          "properties": {
-            "de": { "type": "string" },
-            "en": { "type": "string" }
-          },
-          "required": ["de", "en"]
+          "additionalProperties": { "type": "string" }
         }
       }
     },

--- a/locales/de.json
+++ b/locales/de.json
@@ -28,6 +28,7 @@
     "export": {
       "draft": "Export",
       "csaf": "CSAF Export",
+      "productDescriptionPrefix": "Produktbeschreibung für",
       "error": "{{ errorCount }} Fehler im Dokument. Bitte beheben Sie diese vor dem Export",
       "invalidExport": "Ungültiges CSAF-Dokument",
       "invalidExportConfirm": "Sind Sie sicher, dass Sie ein ungültiges CSAF-Dokument exportieren möchten?"
@@ -91,7 +92,8 @@
         "language": "Sprache",
         "languages": {
           "de": "Deutsch",
-          "en": "Englisch"
+          "en": "Englisch",
+          "nl": "Niederländisch"
         },
         "status": {
           "draft": "Entwurf",

--- a/locales/de.json
+++ b/locales/de.json
@@ -92,8 +92,7 @@
         "language": "Sprache",
         "languages": {
           "de": "Deutsch",
-          "en": "Englisch",
-          "nl": "Niederländisch"
+          "en": "Englisch"
         },
         "status": {
           "draft": "Entwurf",

--- a/locales/en.json
+++ b/locales/en.json
@@ -28,6 +28,7 @@
     "export": {
       "draft": "Export",
       "csaf": "CSAF Export",
+      "productDescriptionPrefix": "Product description for",
       "error": "{{ errorCount }} errors in the document. Please fix them before exporting.",
       "invalidExport": "Invalid CSAF Document",
       "invalidExportConfirm": "Are you sure you want to export an invalid CSAF document?"
@@ -91,7 +92,8 @@
         "language": "Language",
         "languages": {
           "de": "German",
-          "en": "English"
+          "en": "English",
+          "nl": "Dutch"
         },
         "status": {
           "draft": "Draft",

--- a/locales/en.json
+++ b/locales/en.json
@@ -92,8 +92,7 @@
         "language": "Language",
         "languages": {
           "de": "German",
-          "en": "English",
-          "nl": "Dutch"
+          "en": "English"
         },
         "status": {
           "draft": "Draft",

--- a/package-lock.json
+++ b/package-lock.json
@@ -135,7 +135,6 @@
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
@@ -302,6 +301,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -325,6 +325,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -826,13 +827,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -852,9 +853,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -888,9 +889,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -900,7 +901,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
@@ -912,9 +913,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -957,9 +958,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -983,9 +984,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2183,6 +2184,7 @@
       "resolved": "https://registry.npmjs.org/@heroui/system/-/system-2.4.22.tgz",
       "integrity": "sha512-+RVuAxjS2QWyLdYTPxv0IfMjhsxa1GKRSwvpii13bOGEQclwwfaNL2MvBbTt1Mzu/LHaX7kyj0THbZnlOplZOA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@heroui/react-utils": "2.1.13",
         "@heroui/system-rsc": "2.3.19",
@@ -2268,6 +2270,7 @@
       "resolved": "https://registry.npmjs.org/@heroui/theme/-/theme-2.4.22.tgz",
       "integrity": "sha512-naKFQBfp7YwhKGmh7rKCC5EBjV7kdozX21fyGHucDYa6GeFfIKVqXILgZ94HZlfp+LGJfV6U+BuKIflevf0Y+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@heroui/shared-utils": "2.1.11",
         "clsx": "^1.2.1",
@@ -2888,7 +2891,8 @@
       "version": "5.6.5",
       "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.5.tgz",
       "integrity": "sha512-3zwefSMwHpu8iVUW8YYz227sIv6UFqO31p1Bf1ZH/Vom7CmNyUsXjDBlnNzcuhmOL1XfxZ3nvND42kR23XlbcQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@js-joda/timezone": {
       "version": "2.22.0",
@@ -5463,8 +5467,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",
@@ -5537,6 +5540,7 @@
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5547,6 +5551,7 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -5626,6 +5631,7 @@
       "integrity": "sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.41.0",
         "@typescript-eslint/types": "8.41.0",
@@ -5996,8 +6002,7 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.22.tgz",
       "integrity": "sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -6005,6 +6010,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6047,9 +6053,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -6581,13 +6587,26 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -6623,6 +6642,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -6678,7 +6698,6 @@
       "integrity": "sha512-K9ZkuyeJQeqLEyqldbYLG3wjqwpw4BVaAqvmxq3GYKK0b1A/yYQdIcJxkzAOWcNVWhJpRXAPfZFueekiY/L8Dw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.3",
         "confbox": "^0.2.2",
@@ -6859,7 +6878,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -6901,7 +6919,6 @@
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "consola": "^3.2.3"
       }
@@ -7094,7 +7111,6 @@
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
@@ -7439,8 +7455,7 @@
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -7466,8 +7481,7 @@
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.1",
@@ -7496,8 +7510,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.2.2",
@@ -7505,7 +7518,6 @@
       "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7588,6 +7600,7 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -7614,8 +7627,7 @@
       "resolved": "https://registry.npmjs.org/errx/-/errx-0.1.0.tgz",
       "integrity": "sha512-fZmsRiDNv07K6s2KkKFTiD2aIvECa7++PKyD5NC32tpRw46qZA3sOz+aM+/V9V0GDHxVTKLziveV4JhzBHDp9Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -7867,6 +7879,7 @@
       "integrity": "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7928,6 +7941,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8044,9 +8058,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8165,9 +8179,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8255,9 +8269,9 @@
       }
     },
     "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8313,9 +8327,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8820,6 +8834,7 @@
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.22.tgz",
       "integrity": "sha512-ZgGvdxXCw55ZYvhoZChTlG6pUuehecgvEAJz0BHoC5pQKW1EC5xf1Mul1ej5+ai+pVY0pylyFfdl45qnM1/GsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "motion-dom": "^12.23.21",
         "motion-utils": "^12.23.6",
@@ -8999,7 +9014,6 @@
       "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "citty": "^0.1.6",
         "consola": "^3.4.0",
@@ -9333,6 +9347,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.6"
       },
@@ -10098,6 +10113,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -10249,7 +10265,6 @@
       "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -10259,8 +10274,7 @@
       "resolved": "https://registry.npmjs.org/knitwork/-/knitwork-1.2.0.tgz",
       "integrity": "sha512-xYSH7AvuQ6nXkq42x0v5S8/Iry+cfulBz/DJQzhIyESdLD7425jXsPy4vn5cCXU+HhRN2kVw51Vd1K6/By4BQg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -10687,7 +10701,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10811,13 +10824,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -10967,8 +10980,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.21",
@@ -11013,7 +11025,6 @@
       "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "citty": "^0.1.6",
         "consola": "^3.4.2",
@@ -11156,8 +11167,7 @@
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -11388,8 +11398,7 @@
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.0.0.tgz",
       "integrity": "sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -11468,6 +11477,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11499,6 +11509,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11627,7 +11638,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -11643,7 +11653,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11767,7 +11776,6 @@
       "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "defu": "^6.1.4",
         "destr": "^2.0.3"
@@ -11778,6 +11786,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11787,6 +11796,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -11825,8 +11835,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-router": {
       "version": "7.13.0",
@@ -11873,7 +11882,6 @@
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -12220,8 +12228,7 @@
       "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
       "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -12811,6 +12818,7 @@
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
       "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
@@ -12855,9 +12863,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -12886,18 +12894,34 @@
       "license": "ISC"
     },
     "node_modules/test-exclude": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
-      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^10.4.1",
-        "minimatch": "^9.0.4"
+        "minimatch": "^10.2.2"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
+      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/throttleit": {
@@ -12929,8 +12953,7 @@
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
       "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -12970,6 +12993,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13266,6 +13290,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13318,7 +13343,6 @@
       "integrity": "sha512-AbaYw0Nm4mK4qjhns67C+kgxR2YWiwlDBPzxrN8h8C6VtAdCgditAY5Dezu3IJy4XVqAnbrXt9oQJvsn3fyozg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.14.0",
         "estree-walker": "^3.0.3",
@@ -13348,7 +13372,6 @@
       "integrity": "sha512-g/OLFZR2mEfqbC6NC9b2225eCJGvufxq34mj6kM3OmI5gdSL0qyqtnv+9qmsGpAmnzSl6x0IWZj4W+8j2hLkMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.15.0",
         "escape-string-regexp": "^5.0.0",
@@ -13375,7 +13398,6 @@
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13389,7 +13411,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13413,7 +13434,6 @@
       "integrity": "sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
         "acorn": "^8.15.0",
@@ -13430,7 +13450,6 @@
       "integrity": "sha512-JLoggz+PvLVMJo+jZt97hdIIIZ2yTzGgft9e9q8iMrC4ewufl62ekeW7mixBghonn2gVb/ICjyvlmOCUBnJLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3"
@@ -13448,7 +13467,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13462,7 +13480,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13486,7 +13503,6 @@
       "integrity": "sha512-nwNCjxJTjNuLCgFr42fEak5OcLuB3ecca+9ksPFNvtfYSLpjf+iJqSIaSnIile6ZPbKYxI5k2AfXqeopGudK/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "citty": "^0.1.6",
         "defu": "^6.1.4",
@@ -13623,6 +13639,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
       "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -13769,6 +13786,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13782,6 +13800,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -13906,8 +13925,7 @@
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",

--- a/src/components/forms/LanguageSwitcher.tsx
+++ b/src/components/forms/LanguageSwitcher.tsx
@@ -20,7 +20,7 @@ export function LanguageSwitcher() {
     return (
       <Select
         aria-label={t('document.general.language')}
-        className="w-32 mx-auto"
+        className="mx-auto w-32"
         onChange={(e) => changeLanguage(e.target.value)}
         selectedKeys={[i18n.language]}
         size="sm"

--- a/src/components/forms/LanguageSwitcher.tsx
+++ b/src/components/forms/LanguageSwitcher.tsx
@@ -1,9 +1,10 @@
-import { useTranslation } from 'react-i18next'
 import { Button, ButtonGroup } from '@heroui/react'
+import { Select, SelectItem } from '@heroui/select'
 import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 
 export function LanguageSwitcher() {
-  const { i18n } = useTranslation()
+  const { t, i18n } = useTranslation()
 
   const changeLanguage = useCallback(
     (lang: string) => {
@@ -13,22 +14,38 @@ export function LanguageSwitcher() {
     [i18n],
   )
 
+  const languages = Object.keys(i18n.store.data).sort()
+
+  if (languages.length > 2) {
+    return (
+      <Select
+        aria-label={t('document.general.language')}
+        className="w-32 mx-auto"
+        onChange={(e) => changeLanguage(e.target.value)}
+        selectedKeys={[i18n.language]}
+        size="sm"
+      >
+        {languages.map((lang) => (
+          <SelectItem key={lang}>
+            {t(`document.general.languages.${lang}`, lang.toUpperCase())}
+          </SelectItem>
+        ))}
+      </Select>
+    )
+  }
+
   return (
     <ButtonGroup>
-      <Button
-        size="sm"
-        color={i18n.language === 'en' ? 'primary' : 'secondary'}
-        onPress={() => changeLanguage('en')}
-      >
-        EN
-      </Button>
-      <Button
-        size="sm"
-        color={i18n.language === 'de' ? 'primary' : 'secondary'}
-        onPress={() => changeLanguage('de')}
-      >
-        DE
-      </Button>
+      {languages.map((lang) => (
+        <Button
+          key={lang}
+          size="sm"
+          color={i18n.language === lang ? 'primary' : 'secondary'}
+          onPress={() => changeLanguage(lang)}
+        >
+          {lang.toUpperCase()}
+        </Button>
+      ))}
     </ButtonGroup>
   )
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,11 @@ import App from './App'
 import deLocales from '../locales/de.json'
 import enLocales from '../locales/en.json'
 
+const i18nResources = {
+  en: enLocales,
+  de: deLocales,
+}
+
 function getBrowserLanguage(): string {
   // Get browser language (returns full code like 'en-US' or 'de-DE')
   const browserLang = navigator.language
@@ -15,7 +20,7 @@ function getBrowserLanguage(): string {
   const primaryLang = browserLang.split('-')[0]
 
   // Only return if it's one of our supported languages
-  const supportedLanguages = ['en', 'de']
+  const supportedLanguages = Object.keys(i18nResources)
   return supportedLanguages.includes(primaryLang) ? primaryLang : 'en'
 }
 
@@ -28,10 +33,7 @@ const root = ReactDOM.createRoot(rootElement)
 i18n
   .use(initReactI18next) // passes i18n down to react-i18next
   .init({
-    resources: {
-      en: enLocales,
-      de: deLocales,
-    },
+    resources: i18nResources,
     lng: defaultLang,
     fallbackLng: 'en',
     interpolation: {

--- a/src/routes/document-information/General.tsx
+++ b/src/routes/document-information/General.tsx
@@ -32,7 +32,7 @@ export default function General() {
   })
 
   const hasVisitedPage = usePageVisit()
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const { isFieldReadonly, getFieldPlaceholder } = useTemplate()
   const message = useValidationStore((state) => state.messages).filter(
     (m) => m.path === `/document/distribution/tlp`,
@@ -83,7 +83,7 @@ export default function General() {
           isRequired
           placeholder={getFieldPlaceholder('document-information.lang')}
         >
-          {['de', 'en'].map((key) => (
+          {Object.keys(i18n.store.data).map((key) => (
             <SelectItem key={key} textValue={key}>
               {t(`document.general.languages.${key}`)}
             </SelectItem>

--- a/src/utils/csafExport/parseNotes.ts
+++ b/src/utils/csafExport/parseNotes.ts
@@ -1,5 +1,6 @@
 import { TDocumentInformation } from '@/routes/document-information/types/tDocumentInformation'
 import { TProductTreeBranch } from '@/routes/products/types/tProductTreeBranch'
+import i18next from 'i18next'
 import { TConfig } from '../useConfigStore'
 import { TDocumentStore } from '../useDocumentStore'
 import { parseNote, TParsedNote } from './parseNote'
@@ -16,10 +17,6 @@ export function parseNotes(
   documentStore: TDocumentStore,
   config?: TConfig,
 ): TParsedNote[] {
-  const productDescription = config?.exportTexts?.productDescription ?? {
-    en: 'Product description for',
-    de: 'Produktbeschreibung für',
-  }
   const documentInformation: TDocumentInformation =
     documentStore.documentInformation
   const notes = documentInformation.notes.map(parseNote)
@@ -27,10 +24,12 @@ export function parseNotes(
   const productNotes = extractAllProducts(Object.values(documentStore.products))
     ?.filter((p) => p.description.length)
     .map((product) => {
-      const title =
-        documentInformation.lang === 'en'
-          ? `${productDescription.en} ${product.name}`
-          : `${productDescription.de} ${product.name}`
+      const language = documentInformation.lang
+      const prefix =
+        config?.exportTexts?.productDescription?.[language] ??
+        i18next.t('export.productDescriptionPrefix', { lng: language })
+
+      const title = `${prefix} ${product.name}`
 
       return {
         category: 'description',

--- a/src/utils/csafExport/parseNotes.ts
+++ b/src/utils/csafExport/parseNotes.ts
@@ -33,7 +33,7 @@ export function parseNotes(
 
       return {
         category: 'description',
-        text: product.description || '',
+        text: product.description,
         title: title,
       }
     })

--- a/src/utils/useConfigStore.ts
+++ b/src/utils/useConfigStore.ts
@@ -18,8 +18,7 @@ export type TConfig = {
   }
   exportTexts?: {
     productDescription?: {
-      en: string
-      de: string
+      [key: string]: string
     }
   }
   cveApiUrl?: string

--- a/tests/components/forms/Autocomplete.test.tsx
+++ b/tests/components/forms/Autocomplete.test.tsx
@@ -198,4 +198,30 @@ describe('Autocomplete', () => {
       })
     )
   })
+
+  it('should call onChange and onValueChange from useDebounceInput', () => {
+    const onValueChange = vi.fn()
+    const onChange = vi.fn()
+    
+    mockUseDebounceInput.mockClear()
+    
+    render(
+      <Autocomplete 
+        onValueChange={onValueChange} 
+        onChange={onChange}
+      >
+        <div>Option 1</div>
+      </Autocomplete>
+    )
+    
+    expect(mockUseDebounceInput).toHaveBeenCalled()
+    const callArgs = mockUseDebounceInput.mock.calls[0][0]
+    expect(callArgs).toHaveProperty('onChange')
+    
+    const event = { target: { value: 'foo' } }
+    callArgs.onChange(event)
+    
+    expect(onValueChange).toHaveBeenCalledWith('foo')
+    expect(onChange).toHaveBeenCalledWith(event)
+  })
 })

--- a/tests/components/forms/LanguageSwitcher.test.tsx
+++ b/tests/components/forms/LanguageSwitcher.test.tsx
@@ -4,14 +4,26 @@ import '@testing-library/jest-dom'
 import { LanguageSwitcher } from '../../../src/components/forms/LanguageSwitcher'
 
 // Mock react-i18next
-const mockChangeLanguage = vi.fn()
-const mockI18n = {
-  language: 'en',
-  changeLanguage: mockChangeLanguage,
-}
+const { mockI18n, mockChangeLanguage } = vi.hoisted(() => {
+  const changeLanguage = vi.fn()
+  return {
+    mockChangeLanguage: changeLanguage,
+    mockI18n: {
+      language: 'en',
+      changeLanguage,
+      store: {
+        data: {
+          en: {},
+          de: {},
+        },
+      },
+    },
+  }
+})
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
+    t: (key: string) => key,
     i18n: mockI18n,
   }),
 }))

--- a/tests/routes/document-information/General.test.tsx
+++ b/tests/routes/document-information/General.test.tsx
@@ -175,6 +175,16 @@ vi.mock('react-i18next', () => ({
       }
       return translations[key] || key
     },
+    i18n: {
+      language: 'en',
+      changeLanguage: () => {},
+      store: {
+        data: {
+          en: {},
+          de: {},
+        },
+      },
+    },
   }),
 }))
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -96,15 +96,36 @@ vi.mock('@/utils/useConfigStore', () => ({
 // Mock react-i18next
 vi.mock('react-i18next', () => ({
   useTranslation: vi.fn(() => ({
-    t: vi.fn((key) => key),
+    t: (key: string) => key,
     i18n: {
       language: 'en',
       changeLanguage: vi.fn(),
+      store: {
+        data: {
+          en: {},
+          de: {},
+        },
+      },
     },
   })),
   initReactI18next: {
     type: '3rdParty',
     init: vi.fn(),
+  },
+}))
+
+vi.mock('i18next', () => ({
+  default: {
+    t: (key: string, options?: any) => {
+      if (key === 'export.productDescriptionPrefix') {
+        return options?.lng === 'de' ? 'Produktbeschreibung für' : 'Product description for'
+      }
+      return key
+    },
+    language: 'en',
+    changeLanguage: vi.fn(),
+    init: vi.fn(),
+    use: vi.fn().mockReturnThis(),
   },
 }))
 

--- a/tests/utils/csafExport/latestVersion.test.ts
+++ b/tests/utils/csafExport/latestVersion.test.ts
@@ -1,0 +1,44 @@
+import { retrieveLatestVersion } from '../../../src/utils/csafExport/latestVersion'
+
+describe('retrieveLatestVersion', () => {
+    it('should throw an error if history is empty', () => {
+        expect(() => retrieveLatestVersion([])).toThrow('Revision history is empty, cannot retrieve latest version.')
+    })
+
+    it('should return the latest version based on date', () => {
+        const history = [
+            { date: '2023-01-01', number: '1.0.0', summary: 'initial' },
+            { date: '2023-01-02', number: '1.1.0', summary: 'update' },
+            { date: '2023-01-01T12:00:00', number: '1.0.1', summary: 'fix' },
+        ]
+        // 2023-01-02 is the latest date
+        expect(retrieveLatestVersion(history)).toBe('1.1.0')
+    })
+    
+     it('should return the latest version based on date (mixed order)', () => {
+        const history = [
+            { date: '2023-01-02', number: '1.1.0', summary: 'update' },
+             { date: '2023-01-01', number: '1.0.0', summary: 'initial' },
+            { date: '2023-01-03', number: '1.2.0', summary: 'latest' },
+        ]
+        expect(retrieveLatestVersion(history)).toBe('1.2.0')
+    })
+
+    it('should fall back to version comparison if dates are equal', () => {
+        const history = [
+            { date: '2023-01-01', number: '1.0.0', summary: 'old' },
+            { date: '2023-01-01', number: '1.1.0', summary: 'new' }, // Higher version
+        ]
+        expect(retrieveLatestVersion(history)).toBe('1.1.0')
+    })
+
+     it('should handle same date/time correctly considering version', () => {
+         const now = new Date().toISOString()
+        const history = [
+            { date: now, number: '1.0.0', summary: 'old' },
+            { date: now, number: '1.2.0', summary: 'newest' },
+            { date: now, number: '1.1.0', summary: 'new' },
+        ]
+        expect(retrieveLatestVersion(history)).toBe('1.2.0')
+    })
+})

--- a/tests/utils/csafExport/parseNotes.test.ts
+++ b/tests/utils/csafExport/parseNotes.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+import { parseNotes } from '../../../src/utils/csafExport/parseNotes'
+import { TDocumentStore } from '../../../src/utils/useDocumentStore'
+
+vi.mock('i18next', () => ({
+  default: {
+    t: (key: string, options?: any) => {
+      if (key === 'export.productDescriptionPrefix') {
+        return options?.lng === 'de' ? 'Produktbeschreibung für' : 'Product description for'
+      }
+      return key
+    },
+  },
+}))
+
+describe('parseNotes', () => {
+  const mockDocumentStore: TDocumentStore = {
+    documentInformation: {
+      lang: 'en',
+      notes: [],
+    },
+    products: {
+      key1: {
+        id: 'vendor1',
+        name: 'Vendor 1',
+        subBranches: [
+          {
+            id: 'product1',
+            name: 'Product 1',
+            description: 'Description 1',
+          },
+        ],
+      },
+    },
+  } as any
+
+  it('should use default translation when no config is provided', () => {
+    const result = parseNotes(mockDocumentStore)
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        title: 'Product description for Product 1',
+      }),
+    )
+  })
+
+  it('should use config override when provided', () => {
+    const config: any = {
+      exportTexts: {
+        productDescription: {
+          en: 'Custom prefix',
+        },
+      },
+    }
+    const result = parseNotes(mockDocumentStore, config)
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        title: 'Custom prefix Product 1',
+      }),
+    )
+  })
+
+  it('should fallback to translation if config is provided but language is missing', () => {
+    const config: any = {
+      exportTexts: {
+        productDescription: {
+          de: 'Custom prefix',
+        },
+      },
+    }
+    const result = parseNotes(mockDocumentStore, config)
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        title: 'Product description for Product 1',
+      }),
+    )
+  })
+
+  it('should handle German language', () => {
+    const germanStore = {
+      ...mockDocumentStore,
+      documentInformation: {
+        ...mockDocumentStore.documentInformation,
+        lang: 'de',
+      },
+    } as any
+    const result = parseNotes(germanStore)
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        title: 'Produktbeschreibung für Product 1',
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Refactor
- [ ] Documentation Update

## Description

This PR refactors how languages are handled within the application to make adding new languages easier and more dynamic. It also introduces a configurable prefix for product descriptions in the CSAF export, allowing for better localization and customization.

## Key Changes

### 1. Dynamic Language Support
- **`src/main.tsx`**: The supported languages are no longer hardcoded. The application now dynamically generates the list of supported languages based on the imported locale files in the `resources` object.
- **`General.tsx` & `LanguageSwitcher.tsx`**: The language selection dropdowns now automatically list all available languages from the `i18n` instance.
- **Documentation**: Added a "Adding new Languages" section to `README.md` explaining the steps to register a new language.

### 2. Configurable Product Description Prefix
- **`parseNotes.ts`**: The logic for generating product notes in the CSAF export has been updated.
    - It now looks up a localized prefix (e.g., "Product description for") using `i18next`.
    - It supports a configuration override. If `config.exportTexts.productDescription.[lang]` is present, it takes precedence over the translation file.
- **Translation Files**: Added the `export.productDescription` key to `locales/en.json` and `locales/de.json`.
- **Config Schema**: Updated `docs/config-schema.json` to allow overriding the product description prefix using the config file.

### 3. UI Improvements
- **`LanguageSwitcher.tsx`**: Now automatically switches between a `ButtonGroup` (for ≤ 2 languages) and a `Select` dropdown (for > 2 languages), ensuring the UI scales well as more languages are added.

## How to Test
1. **Add a new language (e.g., French):**
   - Create `locales/fr.json`.
   - Import it in `src/main.tsx` and add it to the `resources` object.
   - Verify that "French" now appears in the General tab and the Language Switcher without further code changes.
2. **Check Export:**
   - Generate a CSAF export.
   - Verify that the product description starts with the localized string (e.g., "Product description for...").
   - Add a config override in `.well-known/appspecific/io.github.sec-o-simple.json` for a specific language and verify it changes the export output.


## Related Tickets & Documents

- Closes #175 
