### PR TITLE
feat: Add references to vulnerabilities

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -260,6 +260,16 @@ Products can reference families using the `familyId` field to establish hierarch
 |----------|----------------------------|-------------------------------------------|
 | `status` | Default product status     | `known_affected`, `known_not_affected`, `fixed`, `under_investigation` |
 
+#### References
+
+**Path:** `vulnerabilities.references.default`
+
+| Key        | Description                  | Values                |
+|------------|------------------------------|-----------------------|
+| `summary`  | Default reference summary    | `string`              |
+| `url`      | Default reference URL        | `string`              |
+| `category` | Default reference source     | `self`, `external`    |
+
 #### Flags
 
 **Path:** `vulnerabilities.flags.default`
@@ -290,6 +300,7 @@ Products can reference families using the `familyId` field to establish hierarch
 | `cwe`      | CWE object                   | `object`               |
 | `title`    | Vulnerability title          | `string`               |
 | `notes`    | Notes (array)                | `object[]`             |
+| `references` | References (array)         | `object[]`             |
 | `products` | Products (array)             | `object[]`             |
 
 **Path:** `vulernabilities[].cwe`
@@ -319,6 +330,18 @@ Each key refers to an array of product IDs:
 - `vulnerabilities[].products[].known_not_affected[]`
 - `vulnerabilities[].products[].fixed[]`
 - `vulnerabilities[].products[].under_investigation[]`
+
+#### References (within vulnerability)
+
+**Path:** `vulnerabilities[].references[]`
+
+| Key        | Description             | Values                  |
+|------------|-------------------------|--------------------------|
+| `id`       | Reference ID            | `string`                 |
+| `summary`  | Summary                 | `string`                 |
+| `url`      | URL                     | `string`                 |
+| `category` | Reference source        | `self`, `external`       |
+| `readonly` | Read-only flag          | `boolean`                |
 
 ---
 

--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -220,6 +220,18 @@
           }
         },
 
+        "vulnerabilities.references.default": {
+          "type": "object",
+          "properties": {
+            "summary": { "type": "string" },
+            "url": { "type": "string", "format": "uri" },
+            "category": {
+              "type": "string",
+              "enum": ["self", "external"]
+            }
+          }
+        },
+
         "vulnerabilities.products.default": {
           "type": "object",
           "properties": {
@@ -297,6 +309,23 @@
                     "category": { "type": "string" },
                     "title": { "type": "string" },
                     "content": { "type": "string" }
+                  },
+                  "required": ["id"]
+                }
+              },
+              "references": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "readonly": { "type": "boolean" },
+                    "id": { "type": "string" },
+                    "summary": { "type": "string" },
+                    "url": { "type": "string", "format": "uri" },
+                    "category": {
+                      "type": "string",
+                      "enum": ["self", "external"]
+                    }
                   },
                   "required": ["id"]
                 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -176,6 +176,7 @@
         "dataAddedWarningDescription": "{{count}} neue {{type}} wurden zu den bestehenden Daten hinzugefügt"
       },
       "notes": "Notizen",
+      "references": "Referenzen",
       "products": {
         "title": "Produkte",
         "status": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -175,6 +175,7 @@
         "dataAddedWarningDescription": "{{count}} new {{type}} have been added to existing data"
       },
       "notes": "Notes",
+      "references": "References",
       "products": {
         "title": "Products",
         "status": {

--- a/src/routes/document-information/References.tsx
+++ b/src/routes/document-information/References.tsx
@@ -1,21 +1,14 @@
-import StatusIndicator from '@/components/StatusIndicator'
 import WizardStep from '@/components/WizardStep'
-import ComponentList from '@/components/forms/ComponentList'
-import { Input, Textarea } from '@/components/forms/Input'
-import Select from '@/components/forms/Select'
-import VSplit from '@/components/forms/VSplit'
-import { checkReadOnly, getPlaceholder } from '@/utils/template'
+import { ReferencesList } from '@/routes/shared/ReferencesList'
 import useDocumentStoreUpdater from '@/utils/useDocumentStoreUpdater'
 import { useListState } from '@/utils/useListState'
 import { useListValidation } from '@/utils/validation/useListValidation'
 import usePageVisit from '@/utils/validation/usePageVisit'
-import { usePrefixValidation } from '@/utils/validation/usePrefixValidation'
-import { Alert, SelectItem } from '@heroui/react'
+import { Alert } from '@heroui/react'
 import { useTranslation } from 'react-i18next'
 import { TDocumentInformation } from './types/tDocumentInformation'
 import {
   TDocumentReference,
-  TReferenceCategory,
   getDefaultDocumentReference,
 } from './types/tDocumentReference'
 
@@ -58,90 +51,10 @@ export default function References() {
           ))}
         </Alert>
       )}
-      <ComponentList
-        listState={referencesListState}
-        title="summary"
-        itemLabel={t('ref.reference')}
-        itemBgColor="bg-zinc-50"
-        startContent={StartContent}
-        content={(reference, index) => (
-          <ReferenceForm
-            referenceIndex={index}
-            reference={reference}
-            onChange={referencesListState.updateDataEntry}
-          />
-        )}
+      <ReferencesList
+        referencesListState={referencesListState}
+        csafPath="/document/references"
       />
     </WizardStep>
-  )
-}
-
-function StartContent({ index }: { index: number }) {
-  const { hasErrors } = usePrefixValidation(`/document/references/${index}`)
-
-  return <StatusIndicator hasErrors={hasErrors} hasVisited={true} />
-}
-
-function ReferenceForm({
-  reference,
-  referenceIndex,
-  onChange,
-}: {
-  reference: TDocumentReference
-  referenceIndex: number
-  onChange: (reference: TDocumentReference) => void
-}) {
-  const { t } = useTranslation()
-
-  return (
-    <VSplit>
-      <Select
-        label={t('ref.category')}
-        csafPath={`/document/references/${referenceIndex}/category`}
-        selectedKeys={[reference.category]}
-        isRequired
-        onSelectionChange={(selected) => {
-          if (!selected.anchorKey) return
-
-          onChange({
-            ...reference,
-            category: [...selected][0] as TReferenceCategory,
-          })
-        }}
-        renderValue={(selected) => {
-          if (!selected[0].key) return ''
-          return t(`ref.categories.${selected[0].key}`)
-        }}
-        isDisabled={checkReadOnly(reference, 'category')}
-      >
-        {['external', 'self'].map((key) => (
-          <SelectItem key={key} textValue={key}>
-            {t(`ref.categories.${key}`)}
-          </SelectItem>
-        ))}
-      </Select>
-      <Textarea
-        label={t('ref.summary')}
-        csafPath={`/document/references/${referenceIndex}/summary`}
-        value={reference.summary}
-        onValueChange={(newValue) =>
-          onChange({ ...reference, summary: newValue })
-        }
-        autoFocus={true}
-        placeholder={getPlaceholder(reference, 'summary')}
-        isDisabled={checkReadOnly(reference, 'summary')}
-        isRequired
-      />
-      <Input
-        label={t('ref.url')}
-        type="url"
-        csafPath={`/document/references/${referenceIndex}/url`}
-        value={reference.url}
-        onValueChange={(newValue) => onChange({ ...reference, url: newValue })}
-        isDisabled={checkReadOnly(reference, 'url')}
-        placeholder={getPlaceholder(reference, 'url')}
-        isRequired
-      />
-    </VSplit>
   )
 }

--- a/src/routes/shared/ReferencesList.tsx
+++ b/src/routes/shared/ReferencesList.tsx
@@ -1,0 +1,117 @@
+import StatusIndicator from '@/components/StatusIndicator'
+import ComponentList from '@/components/forms/ComponentList'
+import { Input, Textarea } from '@/components/forms/Input'
+import Select from '@/components/forms/Select'
+import VSplit from '@/components/forms/VSplit'
+import {
+  TDocumentReference,
+  TReferenceCategory,
+  referenceCategories,
+} from '@/routes/document-information/types/tDocumentReference'
+import { checkReadOnly, getPlaceholder } from '@/utils/template'
+import { ListState } from '@/utils/useListState'
+import { usePrefixValidation } from '@/utils/validation/usePrefixValidation'
+import { SelectItem } from '@heroui/react'
+import { useTranslation } from 'react-i18next'
+
+export function ReferencesList({
+  referencesListState,
+  csafPath,
+}: {
+  referencesListState: ListState<TDocumentReference>
+  csafPath: string
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <ComponentList
+      listState={referencesListState}
+      title="summary"
+      itemLabel={t('ref.reference')}
+      itemBgColor="bg-zinc-50"
+      startContent={({ index }) => (
+        <StartContent csafPath={`${csafPath}/${index}`} />
+      )}
+      content={(reference, index) => (
+        <ReferenceForm
+          referenceIndex={index}
+          reference={reference}
+          csafPath={`${csafPath}/${index}`}
+          onChange={referencesListState.updateDataEntry}
+        />
+      )}
+    />
+  )
+}
+
+function StartContent({ csafPath }: { csafPath: string }) {
+  const { hasErrors } = usePrefixValidation(csafPath)
+
+  return <StatusIndicator hasErrors={hasErrors} hasVisited={true} />
+}
+
+function ReferenceForm({
+  reference,
+  referenceIndex,
+  csafPath,
+  onChange,
+}: {
+  reference: TDocumentReference
+  referenceIndex: number
+  csafPath: string
+  onChange: (reference: TDocumentReference) => void
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <VSplit>
+      <Select
+        label={t('ref.category')}
+        csafPath={`${csafPath}/category`}
+        selectedKeys={[reference.category]}
+        isRequired
+        onSelectionChange={(selected) => {
+          if (!selected.anchorKey) return
+
+          onChange({
+            ...reference,
+            category: [...selected][0] as TReferenceCategory,
+          })
+        }}
+        renderValue={(selected) => {
+          if (!selected[0].key) return ''
+          return t(`ref.categories.${selected[0].key}`)
+        }}
+        isDisabled={checkReadOnly(reference, 'category')}
+      >
+        {referenceCategories.map((key) => (
+          <SelectItem key={key} textValue={key}>
+            {t(`ref.categories.${key}`)}
+          </SelectItem>
+        ))}
+      </Select>
+      <Textarea
+        label={t('ref.summary')}
+        csafPath={`${csafPath}/summary`}
+        value={reference.summary}
+        onValueChange={(newValue) =>
+          onChange({ ...reference, summary: newValue })
+        }
+        autoFocus={referenceIndex === 0}
+        placeholder={getPlaceholder(reference, 'summary')}
+        isDisabled={checkReadOnly(reference, 'summary')}
+        isRequired
+      />
+      <Input
+        label={t('ref.url')}
+        type="url"
+        csafPath={`${csafPath}/url`}
+        value={reference.url}
+        onValueChange={(newValue) => onChange({ ...reference, url: newValue })}
+        isDisabled={checkReadOnly(reference, 'url')}
+        placeholder={getPlaceholder(reference, 'url')}
+        isRequired
+      />
+    </VSplit>
+  )
+}

--- a/src/routes/vulnerabilities/References.tsx
+++ b/src/routes/vulnerabilities/References.tsx
@@ -1,0 +1,56 @@
+import VSplit from '@/components/forms/VSplit'
+import {
+  TDocumentReference,
+  getDefaultDocumentReference,
+} from '@/routes/document-information/types/tDocumentReference'
+import { ReferencesList } from '@/routes/shared/ReferencesList'
+import { useListState } from '@/utils/useListState'
+import { useListValidation } from '@/utils/validation/useListValidation'
+import { Alert } from '@heroui/react'
+import { useEffect } from 'react'
+import { TVulnerability } from './types/tVulnerability'
+
+export default function References({
+  vulnerability,
+  vulnerabilityIndex,
+  onChange,
+  isTouched = false,
+}: {
+  vulnerability: TVulnerability
+  vulnerabilityIndex: number
+  onChange: (vulnerability: TVulnerability) => void
+  isTouched?: boolean
+}) {
+  const referencesListState = useListState<TDocumentReference>({
+    initialData: vulnerability.references,
+    generator: getDefaultDocumentReference,
+  })
+
+  useEffect(
+    () => onChange({ ...vulnerability, references: referencesListState.data }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [referencesListState.data],
+  )
+
+  const listValidation = useListValidation(
+    `/vulnerabilities/${vulnerabilityIndex}/references`,
+    referencesListState.data,
+  )
+
+  return (
+    <VSplit className="rounded-lg border border-gray-200 p-4">
+      {(isTouched || listValidation.isTouched) && listValidation.hasErrors && (
+        <Alert color="danger">
+          {listValidation.errorMessages.map((m) => (
+            <p key={m.path}>{m.message}</p>
+          ))}
+        </Alert>
+      )}
+
+      <ReferencesList
+        referencesListState={referencesListState}
+        csafPath={`/vulnerabilities/${vulnerabilityIndex}/references`}
+      />
+    </VSplit>
+  )
+}

--- a/src/routes/vulnerabilities/Vulnerabilities.tsx
+++ b/src/routes/vulnerabilities/Vulnerabilities.tsx
@@ -22,6 +22,7 @@ import { TVulnerability, getDefaultVulnerability } from './types/tVulnerability'
 import useDocumentStore from '@/utils/useDocumentStore'
 import Flags from './Flags'
 import { useFieldValidation } from '@/utils/validation/useFieldValidation'
+import References from './References'
 
 export default function Vulnerabilities() {
   const vulnerabilitiesListState = useListState<TVulnerability>({
@@ -183,6 +184,12 @@ function VulnerabilityForm({
       title: t('vulnerabilities.notes'),
       component: <Notes {...tabProps} />,
       csafPrefix: `${prefix}/notes`,
+    },
+    {
+      key: 'references',
+      title: t('vulnerabilities.references'),
+      component: <References {...tabProps} />,
+      csafPrefix: `${prefix}/references`,
     },
     {
       key: 'products',

--- a/src/routes/vulnerabilities/types/tVulnerability.ts
+++ b/src/routes/vulnerabilities/types/tVulnerability.ts
@@ -4,6 +4,7 @@ import { TVulnerabilityProduct } from './tVulnerabilityProduct'
 import { TVulnerabilityScore } from './tVulnerabilityScore'
 import { TRemediation } from './tRemediation'
 import { TVulnerabilityFlag } from './tVulnerabilityFlag'
+import { TDocumentReference } from '@/routes/document-information/types/tDocumentReference'
 
 export type TCwe = {
   id: string
@@ -16,6 +17,7 @@ export type TVulnerability = {
   cwe?: TCwe
   title: string
   notes: TNote[]
+  references?: TDocumentReference[]
   products: TVulnerabilityProduct[]
   flags: TVulnerabilityFlag[]
   remediations: TRemediation[]
@@ -27,6 +29,7 @@ export function getDefaultVulnerability(): TVulnerability {
     id: uid(),
     title: '',
     notes: [] as TNote[],
+    references: [] as TDocumentReference[],
     products: [] as TVulnerabilityProduct[],
     flags: [] as TVulnerabilityFlag[],
     remediations: [] as TRemediation[],

--- a/src/utils/csafExport/csafExport.ts
+++ b/src/utils/csafExport/csafExport.ts
@@ -202,11 +202,30 @@ export function createCSAFDocument(
               summary: `CVSS v4.0 Score`,
               category: 'external',
             })) || []
+        const userReferences =
+          vulnerability.references?.map((reference) => ({
+            summary: reference.summary,
+            url: reference.url,
+            category: reference.category,
+          })) || []
+        const combinedReferences = [
+          ...userReferences,
+          ...cvss4References,
+        ].filter(
+          (reference, index, references) =>
+            references.findIndex(
+              (candidate) =>
+                candidate.url === reference.url &&
+                candidate.summary === reference.summary &&
+                candidate.category === reference.category,
+            ) === index,
+        )
 
         return {
           cve: vulnerability.cve || undefined,
           title: vulnerability.title,
-          references: cvss4References.length > 0 ? cvss4References : undefined,
+          references:
+            combinedReferences.length > 0 ? combinedReferences : undefined,
           cwe: vulnerability.cwe
             ? {
                 id: vulnerability.cwe.id,

--- a/src/utils/csafImport/parseVulnerabilities.ts
+++ b/src/utils/csafImport/parseVulnerabilities.ts
@@ -7,6 +7,7 @@ import {
   TVulnerability,
   getDefaultVulnerability,
 } from '@/routes/vulnerabilities/types/tVulnerability'
+import { referenceCategories } from '@/routes/document-information/types/tDocumentReference'
 import { TVulnerabilityProduct } from '@/routes/vulnerabilities/types/tVulnerabilityProduct'
 import {
   TVulnerabilityScore,
@@ -26,6 +27,17 @@ export function parseVulnerabilities(
   return (
     csafDocument.vulnerabilities?.map((vulnerability) => {
       const defaultVulnerability = getDefaultVulnerability()
+      const references = vulnerability.references?.map((reference) => ({
+        id: uid(),
+        summary: reference.summary,
+        url: reference.url,
+        category: referenceCategories.includes(
+          reference.category as (typeof referenceCategories)[number],
+        )
+          ? (reference.category as (typeof referenceCategories)[number])
+          : 'external',
+      }))
+
       return {
         id: defaultVulnerability.id,
         cve: vulnerability.cve ?? defaultVulnerability.cve,
@@ -34,6 +46,7 @@ export function parseVulnerabilities(
         notes: vulnerability.notes?.map((note) =>
           parseNote(note as TParsedNote),
         ),
+        ...(references ? { references } : {}),
         products: parseVulnerabilityProducts(
           vulnerability.product_status,
           vulnerabilityProductGenerator,

--- a/src/utils/csafImport/scheme.ts
+++ b/src/utils/csafImport/scheme.ts
@@ -155,6 +155,13 @@ export default {
           title: 'string',
         },
       ],
+      references: [
+        {
+          summary: 'string',
+          url: 'string',
+          category: 'string',
+        },
+      ],
       // Not all statuses are used in the UI, but they are defined here for completeness
       product_status: {
         known_affected: [['string']],

--- a/tests/routes/vulnerabilities/References.test.tsx
+++ b/tests/routes/vulnerabilities/References.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import References from '../../../src/routes/vulnerabilities/References'
+import { TVulnerability } from '../../../src/routes/vulnerabilities/types/tVulnerability'
+
+const mockUseListState = vi.fn()
+const mockUseListValidation = vi.fn()
+
+vi.mock('@/components/forms/VSplit', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="vsplit">{children}</div>
+  ),
+}))
+
+vi.mock('@/routes/shared/ReferencesList', () => ({
+  ReferencesList: ({
+    referencesListState,
+    csafPath,
+  }: {
+    referencesListState: { data: unknown[] }
+    csafPath: string
+  }) => (
+    <div
+      data-testid="references-list"
+      data-path={csafPath}
+      data-count={referencesListState.data.length}
+    >
+      References List
+    </div>
+  ),
+}))
+
+vi.mock('@/utils/useListState', () => ({
+  useListState: (...args: unknown[]) => mockUseListState(...args),
+}))
+
+vi.mock('@/utils/validation/useListValidation', () => ({
+  useListValidation: (...args: unknown[]) => mockUseListValidation(...args),
+}))
+
+vi.mock('@heroui/react', () => ({
+  Alert: ({ children, color }: { children: React.ReactNode; color: string }) => (
+    <div data-testid="alert" data-color={color}>
+      {children}
+    </div>
+  ),
+}))
+
+describe('Vulnerabilities References', () => {
+  const mockOnChange = vi.fn()
+
+  const mockVulnerability: TVulnerability = {
+    id: 'vuln-1',
+    cve: 'CVE-2026-1111',
+    title: 'Test vulnerability',
+    notes: [],
+    references: [
+      {
+        id: 'ref-1',
+        summary: 'Reference 1',
+        url: 'https://example.com/ref1',
+        category: 'external',
+      },
+    ],
+    products: [],
+    flags: [],
+    remediations: [],
+    scores: [],
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockUseListState.mockReturnValue({
+      data: mockVulnerability.references,
+      setData: vi.fn(),
+      updateDataEntry: vi.fn(),
+      removeDataEntry: vi.fn(),
+      addDataEntry: vi.fn(),
+      getId: vi.fn(),
+    })
+
+    mockUseListValidation.mockReturnValue({
+      hasErrors: false,
+      isTouched: false,
+      errorMessages: [],
+    })
+  })
+
+  it('renders references list with vulnerability-specific path', () => {
+    render(
+      <References
+        vulnerability={mockVulnerability}
+        vulnerabilityIndex={3}
+        onChange={mockOnChange}
+      />,
+    )
+
+    expect(screen.getByTestId('vsplit')).toBeInTheDocument()
+    const list = screen.getByTestId('references-list')
+    expect(list).toHaveAttribute('data-path', '/vulnerabilities/3/references')
+    expect(list).toHaveAttribute('data-count', '1')
+  })
+
+  it('calls onChange when list data changes', () => {
+    render(
+      <References
+        vulnerability={mockVulnerability}
+        vulnerabilityIndex={0}
+        onChange={mockOnChange}
+      />,
+    )
+
+    expect(mockOnChange).toHaveBeenCalledWith({
+      ...mockVulnerability,
+      references: mockVulnerability.references,
+    })
+  })
+
+  it('shows validation error alert when touched and invalid', () => {
+    mockUseListValidation.mockReturnValue({
+      hasErrors: true,
+      isTouched: true,
+      errorMessages: [{ path: '/vulnerabilities/0/references', message: 'Invalid references' }],
+    })
+
+    render(
+      <References
+        vulnerability={mockVulnerability}
+        vulnerabilityIndex={0}
+        onChange={mockOnChange}
+      />,
+    )
+
+    expect(screen.getByTestId('alert')).toHaveAttribute('data-color', 'danger')
+    expect(screen.getByText('Invalid references')).toBeInTheDocument()
+  })
+
+  it('shows validation alert when page is touched and invalid', () => {
+    mockUseListValidation.mockReturnValue({
+      hasErrors: true,
+      isTouched: false,
+      errorMessages: [{ path: '/vulnerabilities/0/references', message: 'Missing summary' }],
+    })
+
+    render(
+      <References
+        vulnerability={mockVulnerability}
+        vulnerabilityIndex={0}
+        onChange={mockOnChange}
+        isTouched={true}
+      />,
+    )
+
+    expect(screen.getByText('Missing summary')).toBeInTheDocument()
+  })
+})

--- a/tests/utils/csafExport/csafExport.test.ts
+++ b/tests/utils/csafExport/csafExport.test.ts
@@ -302,4 +302,65 @@ describe('csafExport', () => {
 
     expect(result).toMatchSnapshot()
   })
+
+  it('should export user vulnerability references and CVSS v4 references', () => {
+    const mockStore = createMockDocumentStore()
+    mockStore.vulnerabilities['vuln-1'].references = [
+      {
+        id: 'vuln-ref-1',
+        summary: 'Vendor Security Advisory',
+        url: 'https://example.com/vuln-advisory',
+        category: 'self',
+      },
+    ]
+
+    const result = createCSAFDocument(
+      mockStore,
+      mockGetFullProductName,
+      mockGetRelationshipFullProductName,
+      {
+        template: {},
+        productDatabase: { enabled: false },
+      },
+    )
+
+    expect(result.vulnerabilities[0].references).toEqual(
+      expect.arrayContaining([
+        {
+          summary: 'Vendor Security Advisory',
+          url: 'https://example.com/vuln-advisory',
+          category: 'self',
+        },
+        {
+          summary: 'CVSS v4.0 Score',
+          url: 'https://www.first.org/cvss/calculator/4-0#CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:R/VC:L/VI:L/VA:N/SC:L/SI:L/SA:N',
+          category: 'external',
+        },
+      ]),
+    )
+  })
+
+  it('should deduplicate vulnerability references when they match generated CVSS v4 references', () => {
+    const mockStore = createMockDocumentStore()
+    mockStore.vulnerabilities['vuln-1'].references = [
+      {
+        id: 'vuln-ref-1',
+        summary: 'CVSS v4.0 Score',
+        url: 'https://www.first.org/cvss/calculator/4-0#CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:R/VC:L/VI:L/VA:N/SC:L/SI:L/SA:N',
+        category: 'external',
+      },
+    ]
+
+    const result = createCSAFDocument(
+      mockStore,
+      mockGetFullProductName,
+      mockGetRelationshipFullProductName,
+      {
+        template: {},
+        productDatabase: { enabled: false },
+      },
+    )
+
+    expect(result.vulnerabilities[0].references).toHaveLength(1)
+  })
 })

--- a/tests/utils/csafImport/parseVulnerabilities.test.ts
+++ b/tests/utils/csafImport/parseVulnerabilities.test.ts
@@ -346,6 +346,67 @@ describe('parseVulnerabilities', () => {
     })
   })
 
+  describe('References Handling', () => {
+    it('should parse references when provided', () => {
+      const csafDocument: DeepPartial<TCSAFDocument> = {
+        vulnerabilities: [
+          {
+            references: [
+              {
+                summary: 'Vendor Advisory',
+                url: 'https://example.com/advisory',
+                category: 'self',
+              },
+              {
+                summary: 'External Source',
+                url: 'https://example.com/source',
+                category: 'external',
+              },
+            ],
+            product_status: {},
+          },
+        ],
+      }
+
+      const result = parseVulnerabilities(
+        csafDocument as TCSAFDocument,
+        mockVulnerabilityProductGenerator,
+        mockRemediationGenerator,
+      )
+
+      expect(result[0].references).toHaveLength(2)
+      expect(result[0].references?.[0].summary).toBe('Vendor Advisory')
+      expect(result[0].references?.[0].category).toBe('self')
+      expect(result[0].references?.[1].category).toBe('external')
+      expect(result[0].references?.[0].id).toBeDefined()
+    })
+
+    it('should fallback to external category for unknown categories', () => {
+      const csafDocument: DeepPartial<TCSAFDocument> = {
+        vulnerabilities: [
+          {
+            references: [
+              {
+                summary: 'Unknown Category',
+                url: 'https://example.com/unknown',
+                category: 'other',
+              },
+            ],
+            product_status: {},
+          },
+        ],
+      }
+
+      const result = parseVulnerabilities(
+        csafDocument as TCSAFDocument,
+        mockVulnerabilityProductGenerator,
+        mockRemediationGenerator,
+      )
+
+      expect(result[0].references?.[0].category).toBe('external')
+    })
+  })
+
   describe('Products Handling', () => {
     it('should call parseVulnerabilityProducts with correct parameters', () => {
       const mockProductStatus = { known_affected: ['product-1'] }


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description

This PR adds full support for vulnerability-level references in the CSAF workflow and updates documentation accordingly.

1. Vulnerability references support
- Added a `References` tab within each vulnerability.
- Added `references` to the vulnerability model (`TVulnerability`) with default initialization.

2. UI refactor and reuse
- Refactored document references handling to use a shared references list component (reused form/list behavior instead of duplication).

3. Import/export round-trip fix
- CSAF export now includes user-defined vulnerability references.
- CVSS v4 generated references are still included.
- Export now deduplicates identical references.
- CSAF import now parses vulnerability references and normalizes unsupported categories to `external`.
- Import schema support updated for vulnerability references.

4. Template/schema and docs updates
- `docs/config-schema.json` now supports:
  - `vulnerabilities.references.default`
  - `vulnerabilities[].references[]` item structure in templates
- `docs/CONFIG.md` updated with the new vulnerability references config keys.
- Added locale key for vulnerability references tab in `en` and `de`.

## How to verify

1. Open Vulnerabilities section.
2. Add a vulnerability reference in the new References tab.
3. Export CSAF JSON and verify vulnerabilities[].references includes the entry.
4. Re-import the same JSON and verify reference data is retained.

## Related Tickets & Documents

- Closes #133 
