### PR TITLE
fix: Show proper version number on Github page

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -2,8 +2,8 @@ name: Sec-o-simple Website
 
 on:
   push:
-    branches:
-      - 'main'
+    tags:
+      - 'v*'
 
 permissions:
   contents: write
@@ -20,6 +20,8 @@ jobs:
           node-version: '20'
       - run: npm ci
       - run: npm run build
+        env:
+          BUILD_VERSION: ${{ github.ref_name }}
       - name: Deploy to GitHub Pages
         if: success()
         uses: crazy-max/ghaction-github-pages@v4

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,16 +1,57 @@
 # Release process (Sec-o-Simple)
 
-## Prerequisites
-- Follow SemVer with `vMAJOR.MINOR.PATCH` tags (e.g., `v1.2.0`).
-- Ensure your local `main` is up to date
+Use SemVer tags in the format `vMAJOR.MINOR.PATCH` (for example `v1.2.0`).
 
-## Process
-- Update the Version-Tag in [package.json](./package.json)
-- Create an **annotated** tag locally:
+## End-to-End Release Steps
+
+1. Sync your local repository with `main`.
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
+
+2. Update dependencies and commit the result.
+   ```bash
+   npm update
+   npm install
+   ```
+   This updates dependency versions where allowed by `package.json` and refreshes `package-lock.json`.
+
+3. Check security issues and decide how to handle findings.
+   ```bash
+   npm audit
+   ```
+   If fixes are available and safe, apply them and re-test:
+   ```bash
+   npm audit fix
+   ```
+
+4. Run quality checks and fix all blocking issues before releasing.
+   ```bash
+   npm run lint
+   npm test
+   npm run build
+   ```
+
+5. Bump the version in `package.json` to the target release version.
+
+6. Commit the release preparation changes (version bump, lockfile changes, and any fixes).
+   ```bash
+   git add package.json package-lock.json
+   git commit -m "Prepare release vX.Y.Z"
+   ```
+
+7. Create and push an **annotated** tag.
    ```bash
    git tag -a vX.Y.Z -m "Sec-o-Simple vX.Y.Z: short summary"
+   git push origin main
    git push origin vX.Y.Z
    ```
 
-## Release Notes
-Release Notes are generated automatically by the [release.yml](./.github/workflows/release.yml) workflow.
+8. Wait for [release.yml](./.github/workflows/release.yml) to run.
+   The workflow generates release notes and creates the GitHub release as a **draft**.
+
+9. Open the draft release in GitHub and review everything manually.
+   Check generated notes, included commits, and attached artifacts.
+
+10. Publish the draft release manually when verification is complete.


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description

- Updated workflow trigger in `.github/workflows/github-pages.yml`:
  - From: push to `main`
  - To: push tags matching `v*`
- Passed `BUILD_VERSION` into the build step:
  - `BUILD_VERSION: ${{ github.ref_name }}` on `npm run build`
- Updated the RELEASE documentation to be more precise

## Expected Behavior

- GitHub Pages deploy runs only when a version tag is pushed (e.g. `v1.2.3`).
- Footer version displays the tag value (e.g. `v1.2.3`) instead of a commit hash.

## Related Tickets & Documents

- Closes #172 
