### PR TITLE
fix: Properly set file name for exported file

### DIFF
--- a/src/utils/csafExport/csafExport.ts
+++ b/src/utils/csafExport/csafExport.ts
@@ -15,6 +15,27 @@ import parseScores from './parseScores'
 
 export type TCSAFDocument = ReturnType<typeof createCSAFDocument>
 
+/**
+ * Builds the CSAF export file name from /document/tracking/id.
+ * Rules:
+ * - Convert the tracking ID to lowercase first.
+ * - Replace each sequence of characters outside [+\-a-z0-9] with a single underscore.
+ * - Collapse consecutive underscores to avoid duplicate separators.
+ * - Append "_invalid" when the document is invalid, then append ".json".
+ */
+export function createCSAFExportFilename(
+  trackingId: string | undefined,
+  isValid: boolean,
+): string {
+  const normalizedTrackingId = (trackingId || 'csaf_document')
+    .toLowerCase()
+    .replace(/[^+\-a-z0-9]+/g, '_')
+    .replace(/\++/g, '_')
+    .replace(/_+/g, '_')
+  const suffix = !isValid ? '_invalid' : ''
+  return `${normalizedTrackingId}${suffix}.json`
+}
+
 export function createCSAFDocument(
   documentStore: TDocumentStore,
   getFullProductName: (id: string) => string,
@@ -245,9 +266,10 @@ export function useCSAFExport() {
     // Our created CSAF document has priority, and is handled as the base
     csafDocument = _.merge({}, documentStore.importedCSAFDocument, csafDocument)
 
-    const suffix = !isValid ? '_invalid' : ''
-    const id = documentStore.documentInformation.id || 'csaf_document'
-    const filename = id + suffix + '.json'
+    const filename = createCSAFExportFilename(
+      documentStore.documentInformation.id,
+      isValid,
+    )
 
     download(filename, JSON.stringify(csafDocument, null, 2))
   }

--- a/tests/e2e/software-advisory-export.cy.js
+++ b/tests/e2e/software-advisory-export.cy.js
@@ -200,7 +200,7 @@ describe('Create a new software advisory & export it', () => {
     cy.wait(500)
 
     // Compare the downloaded CSAF export with expected results
-    const downloadPath = 'cypress/downloads/Test-001.json'
+    const downloadPath = 'cypress/downloads/test-001.json'
     cy.task('deleteFileIfExists', downloadPath)
     cy.contains('CSAF Export').click()
     compareCSAFExport(downloadPath, 'tests/fixtures/expected-csaf-export.json')

--- a/tests/utils/csafExport/csafExport.test.ts
+++ b/tests/utils/csafExport/csafExport.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createCSAFDocument } from '../../../src/utils/csafExport/csafExport'
+import {
+  createCSAFDocument,
+  createCSAFExportFilename,
+} from '../../../src/utils/csafExport/csafExport'
 import type { TDocumentStore } from '../../../src/utils/useDocumentStore'
 
 // Mock the current date to ensure consistent snapshots
@@ -301,5 +304,26 @@ describe('csafExport', () => {
     )
 
     expect(result).toMatchSnapshot()
+  })
+
+  describe('createCSAFExportFilename', () => {
+    it('converts tracking id to lowercase and keeps valid characters', () => {
+      expect(createCSAFExportFilename('ESA-2023-B-001', true)).toBe(
+        'esa-2023-b-001.json',
+      )
+    })
+
+    it('replaces invalid character sequences with single underscores', () => {
+      expect(createCSAFExportFilename('2022_#01-A', true)).toBe('2022_01-a.json')
+      expect(createCSAFExportFilename('ESA##+2023-A*', true)).toBe(
+        'esa_2023-a_.json',
+      )
+    })
+
+    it('appends invalid suffix when document is invalid', () => {
+      expect(createCSAFExportFilename('ESA-2023-B-001', false)).toBe(
+        'esa-2023-b-001_invalid.json',
+      )
+    })
   })
 })


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description

This PR updates file name export behavior to match the required `/document/tracking/id` normalization rules (see #173).

## Testing Instructions

1. Start the app.
2. Set the document ID (`/document/tracking/id`) to each value below.
3. Export the CSAF document.
4. Verify the downloaded filename matches the expected result.

- `ESA-2023-B-001` -> `esa-2023-b-001.json`
- `2022_#01-A` -> `2022_01-a.json`
- `ESA##+2023-A*` -> `esa_2023-a_.json`
- Invalid document example: `esa-2023-b-001_invalid.json`

## Related Tickets & Documents

- Closes #173 
