### PR TITLE
feat: Allow config to require inputs

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -55,6 +55,22 @@ The following suffixes can be appended to most fields to enhance configurability
 | `.placeholder`       | UI placeholder text for the field   |
 | `.readonly`          | Marks the field as read-only        |
 
+### Additional Required Fields
+
+**Path:** `template.required[]`
+
+Adds required validation on top of `csaf-validator-lib` (additive logic). Each item must be a CSAF JSON pointer path.
+
+| Key | Description | Values |
+|-----|-------------|--------|
+| `required[]` | List of additional required field paths | JSON pointer strings like `/document/title` |
+
+Notes:
+- Use `*` as a wildcard segment to apply a rule to all existing entries at that level (for example `/document/references/*/url`).
+- To enforce at least one list entry, target index `0` (for example `/document/references/0/url`). This fails when the list is empty and also requires the first entry to contain a value.
+- Empty strings, missing values, empty arrays and empty objects are treated as missing.
+- Existing validator errors are kept; this only adds template-driven required errors.
+
 ### Document Information
 
 **Path:** `document-information`

--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -22,6 +22,13 @@
     "template": {
       "type": "object",
       "properties": {
+        "required": {
+          "type": "array",
+          "description": "Additional required fields as CSAF JSON pointer paths. Use '*' to target all existing entries in an array/object level.",
+          "items": {
+            "type": "string"
+          }
+        },
         "document-information.title": { "type": "string" },
         "document-information.title.readonly": { "type": "boolean" },
         "document-information.id.placeholder": { "type": "string" },

--- a/docs/io.github.sec-o-simple.example.json
+++ b/docs/io.github.sec-o-simple.example.json
@@ -13,6 +13,11 @@
     }
   },
   "template": {
+    "required": [
+      "/document/tracking/id",
+      "/document/references/*/url"
+    ],
+
     "document-information.title": "Test Document",
     "document-information.title.readonly": true,
     "document-information.id.placeholder": "Put your ID here",

--- a/locales/de.json
+++ b/locales/de.json
@@ -376,6 +376,7 @@
     "validation": {
       "error": "Fehler",
       "error_plural": "Fehler",
+      "requiredByTemplate": "Dieses Feld ist erforderlich",
       "errors": {
         "title": "Validierungsfehler",
         "column": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -380,6 +380,7 @@
     "validation": {
       "error": "Error",
       "error_plural": "Error",
+      "requiredByTemplate": "This field is required",
       "errors": {
         "title": "Validation Errors",
         "column": {

--- a/src/utils/useConfigStore.ts
+++ b/src/utils/useConfigStore.ts
@@ -22,7 +22,10 @@ export type TConfig = {
     }
   }
   cveApiUrl?: string
-  template: { [key: string]: unknown }
+  template: {
+    required?: string[]
+    [key: string]: unknown
+  }
 }
 
 export type TConfigStore = {

--- a/src/utils/validation/documentValidator.ts
+++ b/src/utils/validation/documentValidator.ts
@@ -5,12 +5,209 @@ import * as basic from '@secvisogram/csaf-validator-lib/basic.js'
 import validate from '@secvisogram/csaf-validator-lib/validate.js'
 import { TConfig } from '../useConfigStore'
 import { ValidationMessage } from './useValidationStore'
+import i18next from 'i18next'
 
 const tests: unknown[] = [...Object.values(basic)]
 
 export interface ValidationResult {
   isValid: boolean
   messages: ValidationMessage[]
+}
+
+const TEMPLATE_REQUIRED_ERROR_FALLBACK =
+  'This field is required by template configuration'
+
+function getTemplateRequiredErrorMessage(): string {
+  return i18next.t('validation.requiredByTemplate', {
+    defaultValue: TEMPLATE_REQUIRED_ERROR_FALLBACK,
+  })
+}
+
+function decodeJsonPointerSegment(segment: string): string {
+  return segment.replace(/~1/g, '/').replace(/~0/g, '~')
+}
+
+function encodeJsonPointerSegment(segment: string): string {
+  return segment.replace(/~/g, '~0').replace(/\//g, '~1')
+}
+
+function normalizeJsonPointerPath(path: string): string {
+  const trimmedPath = path.trim()
+  if (!trimmedPath) {
+    return ''
+  }
+  return trimmedPath.startsWith('/') ? trimmedPath : `/${trimmedPath}`
+}
+
+function getTemplateRequiredPaths(config?: TConfig): string[] {
+  if (!config?.template || !Array.isArray(config.template.required)) {
+    return []
+  }
+
+  return config.template.required
+    .map((path) => normalizeJsonPointerPath(path))
+    .filter((path) => path.length > 0)
+}
+
+function getValueAtPath(document: unknown, path: string): unknown {
+  if (!path || path === '/') {
+    return document
+  }
+
+  const segments = path
+    .split('/')
+    .slice(1)
+    .map((segment) => decodeJsonPointerSegment(segment))
+
+  let currentValue = document
+  for (const segment of segments) {
+    if (
+      currentValue === null ||
+      currentValue === undefined ||
+      typeof currentValue !== 'object' ||
+      !(segment in currentValue)
+    ) {
+      return undefined
+    }
+
+    currentValue = currentValue[segment as keyof typeof currentValue]
+  }
+
+  return currentValue
+}
+
+function hasValueForRequiredValidation(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return false
+  }
+
+  if (typeof value === 'string') {
+    return value.trim().length > 0
+  }
+
+  if (Array.isArray(value)) {
+    return value.length > 0
+  }
+
+  if (typeof value === 'object') {
+    return Object.keys(value).length > 0
+  }
+
+  return true
+}
+
+function resolveJsonPointerPattern(
+  document: unknown,
+  pattern: string,
+): string[] {
+  const normalizedPattern = normalizeJsonPointerPath(pattern)
+  if (!normalizedPattern) {
+    return []
+  }
+
+  const segments = normalizedPattern
+    .split('/')
+    .slice(1)
+    .map((segment) => decodeJsonPointerSegment(segment))
+  const resolvedPaths = new Set<string>()
+
+  const traverse = (
+    currentValue: unknown,
+    index: number,
+    currentPath: string,
+  ) => {
+    if (index === segments.length) {
+      resolvedPaths.add(currentPath || '/')
+      return
+    }
+
+    const segment = segments[index]
+
+    if (segment === '*') {
+      if (Array.isArray(currentValue)) {
+        currentValue.forEach((item, arrayIndex) => {
+          traverse(item, index + 1, `${currentPath}/${arrayIndex}`)
+        })
+      } else if (currentValue && typeof currentValue === 'object') {
+        Object.entries(currentValue).forEach(([key, value]) => {
+          traverse(
+            value,
+            index + 1,
+            `${currentPath}/${encodeJsonPointerSegment(key)}`,
+          )
+        })
+      }
+      return
+    }
+
+    if (
+      currentValue &&
+      typeof currentValue === 'object' &&
+      segment in currentValue
+    ) {
+      traverse(
+        currentValue[segment as keyof typeof currentValue],
+        index + 1,
+        `${currentPath}/${encodeJsonPointerSegment(segment)}`,
+      )
+      return
+    }
+
+    if (!segments.slice(index).includes('*')) {
+      const missingPath = [
+        currentPath,
+        ...segments
+          .slice(index)
+          .map((value) => encodeJsonPointerSegment(value)),
+      ].join('/')
+      resolvedPaths.add(missingPath)
+    }
+  }
+
+  traverse(document, 0, '')
+
+  return Array.from(resolvedPaths)
+}
+
+function getRequiredFieldMessages(
+  csafDocument: unknown,
+  config: TConfig | undefined,
+  existingMessages: ValidationMessage[],
+): ValidationMessage[] {
+  const requiredPaths = getTemplateRequiredPaths(config)
+  if (requiredPaths.length === 0) {
+    return []
+  }
+
+  const existingErrorPaths = new Set(
+    existingMessages
+      .filter((message) => message.severity === 'error')
+      .map((message) => message.path),
+  )
+  const requiredMessages = new Map<string, ValidationMessage>()
+
+  requiredPaths.forEach((requiredPath) => {
+    const resolvedPaths = requiredPath.includes('*')
+      ? resolveJsonPointerPattern(csafDocument, requiredPath)
+      : [normalizeJsonPointerPath(requiredPath)]
+
+    resolvedPaths.forEach((path) => {
+      if (!path || existingErrorPaths.has(path) || requiredMessages.has(path)) {
+        return
+      }
+
+      const value = getValueAtPath(csafDocument, path)
+      if (!hasValueForRequiredValidation(value)) {
+        requiredMessages.set(path, {
+          path,
+          message: getTemplateRequiredErrorMessage(),
+          severity: 'error',
+        })
+      }
+    })
+  })
+
+  return Array.from(requiredMessages.values())
 }
 
 export async function validateDocument(
@@ -60,6 +257,11 @@ export async function validateDocument(
         })
       })
     })
+
+    messages = [
+      ...messages,
+      ...getRequiredFieldMessages(csafDocument, config, messages),
+    ]
 
     return {
       // We want to use result.isValid when we implemented all fields

--- a/tests/utils/validation/documentValidator.test.ts
+++ b/tests/utils/validation/documentValidator.test.ts
@@ -501,6 +501,301 @@ describe('documentValidator', () => {
         expect.any(Object),
       )
     })
+
+    it('should add required-field errors from template configuration', async () => {
+      ;(createCSAFDocument as Mock).mockReturnValue({
+        document: {
+          tracking: {
+            id: '',
+          },
+        },
+      })
+      ;(validate as Mock).mockResolvedValue({
+        isValid: true,
+        tests: [{ errors: [], warnings: [], infos: [] }],
+      })
+
+      const result = await validateDocument(
+        mockDocumentStore,
+        mockGetFullProductName,
+        mockGetRelationshipFullProductName,
+        {
+          ...mockConfig,
+          template: {
+            required: ['/document/tracking/id'],
+          },
+        },
+      )
+
+      expect(result.isValid).toBe(false)
+      expect(result.messages).toContainEqual({
+        path: '/document/tracking/id',
+        message: expect.any(String),
+        severity: 'error',
+      })
+    })
+
+    it('should validate wildcard required paths for all existing list entries', async () => {
+      ;(createCSAFDocument as Mock).mockReturnValue({
+        document: {
+          references: [
+            {
+              url: '',
+            },
+            {
+              url: 'https://example.org',
+            },
+            {
+              url: '   ',
+            },
+          ],
+        },
+      })
+      ;(validate as Mock).mockResolvedValue({
+        isValid: true,
+        tests: [{ errors: [], warnings: [], infos: [] }],
+      })
+
+      const result = await validateDocument(
+        mockDocumentStore,
+        mockGetFullProductName,
+        mockGetRelationshipFullProductName,
+        {
+          ...mockConfig,
+          template: {
+            required: ['/document/references/*/url'],
+          },
+        },
+      )
+
+      expect(result.isValid).toBe(false)
+      expect(result.messages).toContainEqual({
+        path: '/document/references/0/url',
+        message: expect.any(String),
+        severity: 'error',
+      })
+      expect(result.messages).toContainEqual({
+        path: '/document/references/2/url',
+        message: expect.any(String),
+        severity: 'error',
+      })
+      expect(result.messages).not.toContainEqual({
+        path: '/document/references/1/url',
+        message: expect.any(String),
+        severity: 'error',
+      })
+    })
+
+    it('should not duplicate an existing validator error at the same path', async () => {
+      ;(createCSAFDocument as Mock).mockReturnValue({
+        document: {
+          title: '',
+        },
+      })
+      ;(validate as Mock).mockResolvedValue({
+        isValid: false,
+        tests: [
+          {
+            errors: [
+              {
+                instancePath: '/document/title',
+                message: 'Title is required',
+              },
+            ],
+            warnings: [],
+            infos: [],
+          },
+        ],
+      })
+
+      const result = await validateDocument(
+        mockDocumentStore,
+        mockGetFullProductName,
+        mockGetRelationshipFullProductName,
+        {
+          ...mockConfig,
+          template: {
+            required: ['/document/title'],
+          },
+        },
+      )
+
+      expect(result.messages).toHaveLength(1)
+      expect(result.messages[0]).toEqual({
+        path: '/document/title',
+        message: 'Title is required',
+        severity: 'error',
+      })
+    })
+
+    it('should ignore invalid required configuration entries and still normalize paths', async () => {
+      ;(createCSAFDocument as Mock).mockReturnValue({
+        document: {
+          tracking: {
+            id: '',
+          },
+        },
+      })
+      ;(validate as Mock).mockResolvedValue({
+        isValid: true,
+        tests: [{ errors: [], warnings: [], infos: [] }],
+      })
+
+      const result = await validateDocument(
+        mockDocumentStore,
+        mockGetFullProductName,
+        mockGetRelationshipFullProductName,
+        {
+          ...mockConfig,
+          template: {
+            required: ['', '   ', 'document/tracking/id'],
+          },
+        },
+      )
+
+      expect(result.isValid).toBe(false)
+      expect(result.messages).toContainEqual({
+        path: '/document/tracking/id',
+        message: expect.any(String),
+        severity: 'error',
+      })
+    })
+
+    it('should treat root path as required and fail for empty root object', async () => {
+      ;(createCSAFDocument as Mock).mockReturnValue({})
+      ;(validate as Mock).mockResolvedValue({
+        isValid: true,
+        tests: [{ errors: [], warnings: [], infos: [] }],
+      })
+
+      const result = await validateDocument(
+        mockDocumentStore,
+        mockGetFullProductName,
+        mockGetRelationshipFullProductName,
+        {
+          ...mockConfig,
+          template: {
+            required: ['/'],
+          },
+        },
+      )
+
+      expect(result.isValid).toBe(false)
+      expect(result.messages).toContainEqual({
+        path: '/',
+        message: expect.any(String),
+        severity: 'error',
+      })
+    })
+
+    it('should add required error for missing nested non-wildcard path', async () => {
+      ;(createCSAFDocument as Mock).mockReturnValue({
+        document: {
+          tracking: {},
+        },
+      })
+      ;(validate as Mock).mockResolvedValue({
+        isValid: true,
+        tests: [{ errors: [], warnings: [], infos: [] }],
+      })
+
+      const result = await validateDocument(
+        mockDocumentStore,
+        mockGetFullProductName,
+        mockGetRelationshipFullProductName,
+        {
+          ...mockConfig,
+          template: {
+            required: ['/document/tracking/id'],
+          },
+        },
+      )
+
+      expect(result.isValid).toBe(false)
+      expect(result.messages).toContainEqual({
+        path: '/document/tracking/id',
+        message: expect.any(String),
+        severity: 'error',
+      })
+    })
+
+    it('should support wildcard traversal over objects', async () => {
+      ;(createCSAFDocument as Mock).mockReturnValue({
+        document: {
+          publisher: {
+            vendor: {
+              name: '',
+            },
+            translator: {
+              name: 'Translator Team',
+            },
+          },
+        },
+      })
+      ;(validate as Mock).mockResolvedValue({
+        isValid: true,
+        tests: [{ errors: [], warnings: [], infos: [] }],
+      })
+
+      const result = await validateDocument(
+        mockDocumentStore,
+        mockGetFullProductName,
+        mockGetRelationshipFullProductName,
+        {
+          ...mockConfig,
+          template: {
+            required: ['/document/publisher/*/name'],
+          },
+        },
+      )
+
+      expect(result.isValid).toBe(false)
+      expect(result.messages).toContainEqual({
+        path: '/document/publisher/vendor/name',
+        message: expect.any(String),
+        severity: 'error',
+      })
+      expect(result.messages).not.toContainEqual({
+        path: '/document/publisher/translator/name',
+        message: expect.any(String),
+        severity: 'error',
+      })
+    })
+
+    it('should create missing path from wildcard pattern when property is absent', async () => {
+      ;(createCSAFDocument as Mock).mockReturnValue({
+        document: {
+          references: [
+            {
+              summary: 'Reference without URL',
+            },
+          ],
+        },
+      })
+      ;(validate as Mock).mockResolvedValue({
+        isValid: true,
+        tests: [{ errors: [], warnings: [], infos: [] }],
+      })
+
+      const result = await validateDocument(
+        mockDocumentStore,
+        mockGetFullProductName,
+        mockGetRelationshipFullProductName,
+        {
+          ...mockConfig,
+          template: {
+            required: ['/document/references/*/url'],
+          },
+        },
+      )
+
+      expect(result.isValid).toBe(false)
+      expect(result.messages).toContainEqual({
+        path: '/document/references/0/url',
+        message: expect.any(String),
+        severity: 'error',
+      })
+    })
   })
 
   describe('ValidationResult interface', () => {


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [x] Documentation Update

## Description

This PR adds configurable, additive required-field validation via template configuration, on top of `csaf-validator-lib`.

### What changed

- Added support for `template.required` in configuration handling.
- Extended document validation to append template-driven required errors (without replacing existing validator errors).
- Added JSON Pointer support for required paths, including wildcard segments (*) and indexed paths (for example list index 0).
- Updated config schema and documentation for the new required-field behavior.
- Extended validator tests to cover new logic branches and improve coverage.

### Behavior highlights

- Required rules are additive: existing csaf-validator-lib findings remain unchanged.
- Missing values include empty strings, whitespace-only strings, undefined/null, empty arrays, and empty objects.
- Duplicate errors for the same path are avoided when an existing validator error is already present.
- At least-one-list-entry enforcement is possible with a path like /document/references/0/url.

## Related Tickets & Documents

- Closes #84 

## Test Instructions

1.  Add template.required paths to the app config for a field which is not required usually.
2. Confirm required-field messages appear for missing values.
3. For list behavior, use a rule like `/document/references/0/url` and confirm an error appears when the list is empty (or first entry URL is empty).
6. For wildcard behavior, use a rule like `/document/references/*/url` and confirm every existing list entry requires the input.