### PR TITLE
feat: Show info regarding why version is locked

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -291,7 +291,11 @@
     "product_version": {
       "label": "Version",
       "name": "Versionname",
-      "description": "Versionbeschreibung"
+      "description": "Versionbeschreibung",
+      "readonly_reason": {
+        "imported_with_identification_helper": "Dieser Versionsname ist gesperrt, weil das importierte Produkt einen oder mehrere Identifikationshelfer hat.",
+        "full_product_name_mismatch": "Dieser Versionsname ist gesperrt, weil der festgelegte vollständige Produktname nicht mit dem automatisch generierten übereinstimmt."
+      }
     },
     "product_family": {
       "label": "Produktfamilie",

--- a/locales/en.json
+++ b/locales/en.json
@@ -295,7 +295,11 @@
     "product_version": {
       "label": "Version",
       "name": "Name",
-      "description": "Description"
+      "description": "Description",
+      "readonly_reason": {
+        "imported_with_identification_helper": "This version name is locked because the imported product has one or more identification helpers.",
+        "full_product_name_mismatch": "This version name is locked because the set full product name does not match the automatically generated one."
+      }
     },
     "product_family": {
       "label": "Product Family",

--- a/src/routes/products/Version.tsx
+++ b/src/routes/products/Version.tsx
@@ -4,10 +4,12 @@ import WizardStep from '@/components/WizardStep'
 import useDocumentStore from '@/utils/useDocumentStore'
 import { useProductTreeBranch } from '@/utils/useProductTreeBranch'
 import { useRelationships } from '@/utils/useRelationships'
+import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Accordion, AccordionItem } from '@heroui/accordion'
 import { Chip } from '@heroui/chip'
 import { Modal, useDisclosure } from '@heroui/modal'
-import { BreadcrumbItem } from '@heroui/react'
+import { BreadcrumbItem, Tooltip } from '@heroui/react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router'
@@ -181,16 +183,42 @@ export default function Version() {
                           `/products/management/version/${x}`
                         }
                         labelGenerator={(x) => {
-                          const findProductTreeBranch =
+                          const versionBranch =
                             findProductTreeBranchWithParents(x)
 
-                          if (!findProductTreeBranch) {
+                          if (!versionBranch) {
                             return t('untitled.product_version')
                           }
 
+                          const { name, isReadonly, readonlyReason } =
+                            getPTBName(versionBranch)
+
+                          const displayName =
+                            name ?? t('untitled.product_version')
+                          const readonlyReasonText =
+                            isReadonly && readonlyReason
+                              ? t(
+                                  `product_version.readonly_reason.${readonlyReason}`,
+                                )
+                              : undefined
+
                           return (
-                            getPTBName(findProductTreeBranch).name ??
-                            t('untitled.product_version')
+                            <span className="flex items-center gap-1">
+                              <span>{displayName}</span>
+                              {readonlyReasonText && (
+                                <Tooltip showArrow content={readonlyReasonText}>
+                                  <span
+                                    className="inline-flex text-zinc-500"
+                                    aria-label={readonlyReasonText}
+                                  >
+                                    <FontAwesomeIcon
+                                      icon={faCircleInfo}
+                                      size="sm"
+                                    />
+                                  </span>
+                                </Tooltip>
+                              )}
+                            </span>
                           )
                         }}
                       />

--- a/src/routes/products/components/PTBEditForm.tsx
+++ b/src/routes/products/components/PTBEditForm.tsx
@@ -38,9 +38,17 @@ export function PTBCreateEditForm({
 }: PTBCreateEditFormProps) {
   const { t } = useTranslation()
   const { getPTBName, families } = useProductTreeBranch()
-  const { name: ptbName, isReadonly } = ptb
-    ? getPTBName(ptb)
-    : { name: '', isReadonly: false }
+  const {
+    name: ptbName,
+    isReadonly,
+    readonlyReason,
+  } = ptb ? getPTBName(ptb) : { name: '', isReadonly: false }
+  const isNameDisabled = ptb
+    ? checkTemplateReadonly(ptb, 'name') || isReadonly
+    : false
+  const versionNameReadonlyReason = readonlyReason
+    ? t(`product_version.readonly_reason.${readonlyReason}`)
+    : undefined
   const [name, setName] = useState(ptb?.name ?? '')
   const [description, setDescription] = useState(ptb?.description ?? '')
   const [type, setType] = useState(ptb?.type ?? 'Software')
@@ -66,11 +74,16 @@ export function PTBCreateEditForm({
               autoFocus
               value={isReadonly ? (ptbName ?? '') : name}
               onValueChange={setName}
-              isDisabled={
-                ptb ? checkTemplateReadonly(ptb, 'name') || isReadonly : false
-              }
+              isDisabled={isNameDisabled}
               placeholder={ptb ? getPlaceholder(ptb, 'name') : undefined}
             />
+            {category === 'product_version' &&
+              isNameDisabled &&
+              versionNameReadonlyReason && (
+                <p className="text-sm text-zinc-500">
+                  {versionNameReadonlyReason}
+                </p>
+              )}
             {category === 'product_name' && (
               <Textarea
                 label={t(`${category}.description`)}

--- a/src/routes/products/components/ProductCard.tsx
+++ b/src/routes/products/components/ProductCard.tsx
@@ -1,7 +1,9 @@
 import IconButton from '@/components/forms/IconButton'
 import { useProductTreeBranch } from '@/utils/useProductTreeBranch'
-import { faCodeFork } from '@fortawesome/free-solid-svg-icons'
+import { faCircleInfo, faCodeFork } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Chip } from '@heroui/chip'
+import { Tooltip } from '@heroui/react'
 import { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
@@ -58,9 +60,30 @@ export default function ProductCard({
             linkGenerator={(version) =>
               `/products/management/version/${version.id}`
             }
-            labelGenerator={(x) =>
-              getPTBName(x).name ?? t('untitled.product_version')
-            }
+            labelGenerator={(x) => {
+              const { name, isReadonly, readonlyReason } = getPTBName(x)
+              const displayName = name ?? t('untitled.product_version')
+              const readonlyReasonText =
+                isReadonly && readonlyReason
+                  ? t(`product_version.readonly_reason.${readonlyReason}`)
+                  : undefined
+
+              return (
+                <span className="flex items-center gap-1">
+                  <span>{displayName}</span>
+                  {readonlyReasonText && (
+                    <Tooltip showArrow content={readonlyReasonText}>
+                      <span
+                        className="inline-flex text-zinc-500"
+                        aria-label={readonlyReasonText}
+                      >
+                        <FontAwesomeIcon icon={faCircleInfo} size="sm" />
+                      </span>
+                    </Tooltip>
+                  )}
+                </span>
+              )
+            }}
           />
         )}
       </div>

--- a/src/routes/products/components/TagList.tsx
+++ b/src/routes/products/components/TagList.tsx
@@ -3,11 +3,12 @@ import { faX } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Chip } from '@heroui/chip'
 import { cn } from '@heroui/react'
+import { ReactNode } from 'react'
 import { useNavigate } from 'react-router'
 
 export type TagListProps<T> = {
   items: T[]
-  labelGenerator?: (item: T) => string
+  labelGenerator?: (item: T) => ReactNode
   linkGenerator?: (item: T) => string
   onRemove?: (item: T) => void
 }

--- a/src/utils/useProductTreeBranch.ts
+++ b/src/utils/useProductTreeBranch.ts
@@ -16,6 +16,10 @@ export type TSelectableFullProductName = {
   }
 }
 
+export type TProductTreeBranchReadonlyReason =
+  | 'imported_with_identification_helper'
+  | 'full_product_name_mismatch'
+
 export function useProductTreeBranch() {
   const { t } = useTranslation()
   const products = Object.values(useDocumentStore((store) => store.products))
@@ -88,9 +92,11 @@ export function useProductTreeBranch() {
   ): {
     isReadonly?: boolean
     name?: string
+    readonlyReason?: TProductTreeBranchReadonlyReason
   } => {
     let isNameReadonly = false
     let name = branch.name
+    let readonlyReason: TProductTreeBranchReadonlyReason | undefined
 
     if (
       branch.category === 'product_version' &&
@@ -99,9 +105,11 @@ export function useProductTreeBranch() {
     ) {
       isNameReadonly = true
       name = branch.productName
+      readonlyReason = 'full_product_name_mismatch'
     } else if (!!branch.identificationHelper) {
       isNameReadonly = true
       name = getFullProductName(branch.id)
+      readonlyReason = 'imported_with_identification_helper'
     }
 
     if (!name) {
@@ -111,6 +119,7 @@ export function useProductTreeBranch() {
     return {
       name,
       isReadonly: isNameReadonly,
+      readonlyReason,
     }
   }
 

--- a/tests/routes/document-selection/EditDocument.test.tsx
+++ b/tests/routes/document-selection/EditDocument.test.tsx
@@ -773,9 +773,11 @@ describe('EditDocument', () => {
     await waitFor(() => {
       expect(screen.getByTestId('button-edit-document')).not.toBeDisabled()
     })
-    
-    // Test that the jsonObject was set and useEffect dependencies work correctly
-    expect(mockIsSOSDraft).toHaveBeenCalledWith({ valid: 'sos-document' })
-    expect(mockIsCSAFDocument).toHaveBeenCalledWith({ valid: 'sos-document' })
+
+    // Wait for useEffect validators to run
+    await waitFor(() => {
+      expect(mockIsSOSDraft).toHaveBeenCalledWith({ valid: 'sos-document' })
+      expect(mockIsCSAFDocument).toHaveBeenCalledWith({ valid: 'sos-document' })
+    })
   })
 })

--- a/tests/routes/products/Version.test.tsx
+++ b/tests/routes/products/Version.test.tsx
@@ -36,6 +36,10 @@ vi.mock('react-i18next', () => ({
         'products.relationship.categories.installed_with': 'Installed With',
         'products.relationship.categories.optional_component_of':
           'Optional Component Of',
+        'product_version.readonly_reason.imported_with_identification_helper':
+          'Version name is managed by imported identification helper.',
+        'product_version.readonly_reason.full_product_name_mismatch':
+          'Version name is locked because full product name does not match.',
       }
       return translations[key] || key
     }),
@@ -59,6 +63,7 @@ const mockGetPTBName = vi.fn((product: any) => {
   return {
     name: product.name || fallbackName,
     isReadonly: false,
+    readonlyReason: undefined,
   }
 })
 const mockGetRelationshipsBySourceVersion = vi.fn()
@@ -168,6 +173,11 @@ vi.mock('@heroui/chip', () => ({
 vi.mock('@heroui/react', () => ({
   BreadcrumbItem: ({ children, href }: any) => (
     <div data-testid="breadcrumb-item" data-href={href}>
+      {children}
+    </div>
+  ),
+  Tooltip: ({ children, content }: any) => (
+    <div data-testid="tooltip" data-content={content}>
       {children}
     </div>
   ),
@@ -538,6 +548,37 @@ describe('Version', () => {
       expect(tagItems[0]).toHaveAttribute(
         'data-link',
         '/products/management/version/version-2',
+      )
+    })
+
+    it('should show readonly info tooltip in version chip when version name is not editable', () => {
+      mockFindProductTreeBranchWithParents.mockImplementation((id?: string) => {
+        if (id === 'version-2') {
+          return {
+            ...mockProductVersion,
+            id: 'version-2',
+            name: 'Version 2.0',
+          }
+        }
+
+        return mockProductVersion
+      })
+
+      mockGetPTBName.mockImplementation((product: any) => ({
+        name: product.name || 'Untitled Version',
+        isReadonly: product.id === 'version-2',
+        readonlyReason:
+          product.id === 'version-2'
+            ? 'imported_with_identification_helper'
+            : undefined,
+      }))
+
+      render(<Version />)
+
+      const tooltip = screen.getByTestId('tooltip')
+      expect(tooltip).toHaveAttribute(
+        'data-content',
+        'Version name is managed by imported identification helper.',
       )
     })
 

--- a/tests/routes/products/components/PTBEditForm.test.tsx
+++ b/tests/routes/products/components/PTBEditForm.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 // Mock @heroui/react to include Autocomplete
@@ -50,7 +50,18 @@ vi.mock('../../../../src/utils/useProductTreeBranch', () => ({
   useProductTreeBranch: vi.fn(() => ({
     getPTBName: vi.fn((branch) => ({
       name: branch.name,
-      isReadonly: false,
+      isReadonly:
+        !!branch.identificationHelper ||
+        (branch.category === 'product_version' &&
+          branch.productName !== undefined &&
+          branch.productName !== 'Mock Full Product Name'),
+      readonlyReason: branch.identificationHelper
+        ? 'imported_with_identification_helper'
+        : branch.category === 'product_version' &&
+            branch.productName !== undefined &&
+            branch.productName !== 'Mock Full Product Name'
+          ? 'full_product_name_mismatch'
+          : undefined,
     })),
     families: [
       { id: 'family1', name: 'Test Family 1' },
@@ -80,8 +91,8 @@ vi.mock('@heroui/modal', () => ({
 }))
 
 vi.mock('@heroui/button', () => ({
-  Button: ({ children, ...props }: any) => (
-    <button {...props} data-testid="button">
+  Button: ({ children, onPress, ...props }: any) => (
+    <button {...props} onClick={onPress} data-testid="button">
       {children}
     </button>
   ),
@@ -153,5 +164,76 @@ describe('PTBCreateEditForm', () => {
     )
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('should show read-only reason when imported version has identification helper', () => {
+    const versionPTB: TProductTreeBranch = {
+      id: 'test-version-1',
+      category: 'product_version',
+      name: '1.0.0',
+      description: '',
+      subBranches: [],
+      identificationHelper: {
+        cpe: 'cpe:2.3:a:test:product:1.0.0:*:*:*:*:*:*:*',
+      },
+    }
+
+    render(
+      <PTBCreateEditForm
+        ptb={versionPTB}
+        category="product_version"
+        onSave={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByText(
+        'product_version.readonly_reason.imported_with_identification_helper',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('should show read-only reason when full product name does not match', () => {
+    const versionPTB: TProductTreeBranch = {
+      id: 'test-version-2',
+      category: 'product_version',
+      name: '1.0.1',
+      description: '',
+      subBranches: [],
+      productName: 'Stored Name That Does Not Match',
+    }
+
+    render(
+      <PTBCreateEditForm
+        ptb={versionPTB}
+        category="product_version"
+        onSave={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByText(
+        'product_version.readonly_reason.full_product_name_mismatch',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('should call onSave when save button is pressed', () => {
+    const onSave = vi.fn()
+
+    render(<PTBCreateEditForm category="product_name" onSave={onSave} />)
+
+    const saveButton = screen.getByText('common.save')
+    fireEvent.click(saveButton)
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: '',
+        description: '',
+        type: 'Software',
+        familyId: null,
+      }),
+    )
   })
 })

--- a/tests/routes/products/components/ProductCard.test.tsx
+++ b/tests/routes/products/components/ProductCard.test.tsx
@@ -4,6 +4,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ProductCard from '../../../../src/routes/products/components/ProductCard'
 import { TProductTreeBranch } from '../../../../src/routes/products/types/tProductTreeBranch'
 
+vi.mock('@fortawesome/react-fontawesome', () => ({
+  FontAwesomeIcon: ({ icon, size, ...props }: any) => (
+    <i data-testid="font-awesome-icon" data-icon={icon} data-size={size} {...props} />
+  ),
+}))
+
 // Mock all external dependencies
 vi.mock('../../../../src/components/forms/IconButton', () => ({
   default: ({ icon, tooltip, onPress, ...props }: any) => (
@@ -54,6 +60,15 @@ vi.mock('../../../../src/utils/useProductTreeBranch', () => ({
 
 vi.mock('@fortawesome/free-solid-svg-icons', () => ({
   faCodeFork: 'faCodeFork',
+  faCircleInfo: 'faCircleInfo',
+}))
+
+vi.mock('@heroui/react', () => ({
+  Tooltip: ({ children, content }: any) => (
+    <div data-testid="tooltip" data-content={content}>
+      {children}
+    </div>
+  ),
 }))
 
 vi.mock('@heroui/chip', () => ({
@@ -532,6 +547,35 @@ describe('ProductCard', () => {
 
       const infoCard = screen.getByTestId('info-card')
       expect(infoCard).toHaveAttribute('data-link-to', 'product/different-id')
+    })
+  })
+
+  describe('Readonly version chip info', () => {
+    it('should show info tooltip when version chip label is readonly', () => {
+      mockGetPTBName.mockImplementation((branch: any) => {
+        if (branch.id === 'sub-2') {
+          return {
+            name: 'Vendor Product 2.0',
+            isReadonly: true,
+            readonlyReason: 'imported_with_identification_helper',
+          }
+        }
+
+        return {
+          name: branch.name || 'Untitled Version',
+          isReadonly: false,
+          readonlyReason: undefined,
+        }
+      })
+
+      renderWithRouter(<ProductCard product={mockProductWithSubBranches} />)
+
+      const tooltips = screen.getAllByTestId('tooltip')
+      expect(tooltips).toHaveLength(1)
+      expect(tooltips[0]).toHaveAttribute(
+        'data-content',
+        'product_version.readonly_reason.imported_with_identification_helper',
+      )
     })
   })
 })

--- a/tests/utils/useProductTreeBranch.test.ts
+++ b/tests/utils/useProductTreeBranch.test.ts
@@ -1105,6 +1105,53 @@ describe('useProductTreeBranch', () => {
     })
   })
 
+  describe('getPTBName', () => {
+    it('should return readonly reason for identification helper imports', () => {
+      const { result } = renderHook(() => useProductTreeBranch())
+
+      const importedVersion = {
+        ...mockProducts[0].subBranches[0].subBranches[0],
+        identificationHelper: {
+          cpe: 'cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*',
+        },
+      }
+
+      const ptbName = result.current.getPTBName(importedVersion)
+
+      expect(ptbName.isReadonly).toBe(true)
+      expect(ptbName.readonlyReason).toBe(
+        'imported_with_identification_helper',
+      )
+      expect(ptbName.name).toBe('Vendor A Product A Version 1.0')
+    })
+
+    it('should return readonly reason for full product name mismatch', () => {
+      const { result } = renderHook(() => useProductTreeBranch())
+
+      const mismatchedVersion = {
+        ...mockProducts[0].subBranches[0].subBranches[0],
+        productName: 'Old Stored Full Product Name',
+      }
+
+      const ptbName = result.current.getPTBName(mismatchedVersion)
+
+      expect(ptbName.isReadonly).toBe(true)
+      expect(ptbName.readonlyReason).toBe('full_product_name_mismatch')
+      expect(ptbName.name).toBe('Old Stored Full Product Name')
+    })
+
+    it('should return editable name without readonly reason by default', () => {
+      const { result } = renderHook(() => useProductTreeBranch())
+
+      const version = mockProducts[0].subBranches[0].subBranches[0]
+      const ptbName = result.current.getPTBName(version)
+
+      expect(ptbName.isReadonly).toBe(false)
+      expect(ptbName.readonlyReason).toBeUndefined()
+      expect(ptbName.name).toBe('Version 1.0')
+    })
+  })
+
   describe('Edge Cases', () => {
     it('should handle circular references gracefully in filter operations', () => {
       const { result } = renderHook(() => useProductTreeBranch())


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
- Adds a short localized explanation in the edit-version modal when the version name is not editable.
- Covers both lock reasons: imported with identification helper, and full product name mismatch.
- Adds an info icon with tooltip on clickable version chips wherever readonly/full-product-name logic is used.

## Screenshots
<img width="1272" height="558" alt="1" src="https://github.com/user-attachments/assets/0d09e60b-f50d-4c35-bcb0-50dfc10a0e47" />
<img width="721" height="375" alt="2" src="https://github.com/user-attachments/assets/39427736-d852-4e0d-ac14-6bc9f819e428" />

## How to Test

1. Open product version edit modal for a readonly version and confirm name is disabled + explanation text is shown.
2. In product/version chip lists, confirm readonly versions show full product name and an info icon tooltip.
3. Confirm normal editable versions do not show the tooltip icon.

## Related Tickets & Documents

- Closes #137
