### PR TITLE
feat: Add checkbox to automatically apply known affected products

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -208,6 +208,7 @@
         "baseScoreDescription": "Basis Bewertung wird aus dem Vektorstring berechnet",
         "baseSeverity": "Basis Schweregrad",
         "baseSeverityDescription": "Basis Schweregrad wird aus dem Vektorstring berechnet",
+        "applyAllKnownAffectedProducts": "Alle bekannten betroffenen Produkte anwenden",
         "productsDescription": "Wählen Sie die betroffenen Produkte oder diejenigen aus, die derzeit untersucht werden"
       },
       "remediations": "Behebungen",
@@ -225,6 +226,7 @@
         "details": "Details",
         "url": "URL",
         "products.empty": "Keine Produkte hinzugefügt",
+        "applyAllKnownAffectedProducts": "Alle bekannten betroffenen Produkte anwenden",
         "productsDescription": "Wählen Sie die betroffenen Produkte aus",
         "restartRequired": "Neustart erforderlich"
       },

--- a/locales/en.json
+++ b/locales/en.json
@@ -207,6 +207,7 @@
         "baseScoreDescription": "Base score is calculated from the vector string",
         "baseSeverity": "Base Severity",
         "baseSeverityDescription": "Base severity is calculated from the vector string",
+        "applyAllKnownAffectedProducts": "Apply all known affected products",
         "productsDescription": "Select the affected products or those currently under investigation"
       },
       "remediations": "Remediations",
@@ -224,6 +225,7 @@
         "details": "Details",
         "url": "URL",
         "products.empty": "No products added",
+        "applyAllKnownAffectedProducts": "Apply all known affected products",
         "productsDescription": "Select the affected products",
         "restartRequired": "Restart required"
       },

--- a/src/routes/vulnerabilities/Remediations.tsx
+++ b/src/routes/vulnerabilities/Remediations.tsx
@@ -15,9 +15,9 @@ import { useFieldValidation } from '@/utils/validation/useFieldValidation'
 import { useListValidation } from '@/utils/validation/useListValidation'
 import { usePrefixValidation } from '@/utils/validation/usePrefixValidation'
 import { Chip } from '@heroui/chip'
-import { Alert } from '@heroui/react'
+import { Alert, Checkbox } from '@heroui/react'
 import { SelectItem } from '@heroui/select'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import ProductsTagList from './components/ProductsTagList'
 import {
@@ -47,7 +47,19 @@ export default function Remediations({
     generator: remediationGenerator,
   })
   const { getSelectableRefs } = useProductTreeBranch()
-  let refs = getSelectableRefs()
+  const refs = getSelectableRefs()
+
+  const knownAffectedProductIds = useMemo(
+    () => [
+      ...new Set(
+        vulnerability.products
+          .filter((p) => p.status === 'known_affected')
+          .map((p) => p.productId)
+          .filter((id): id is string => Boolean(id)),
+      ),
+    ],
+    [vulnerability.products],
+  )
 
   useEffect(
     () =>
@@ -62,9 +74,7 @@ export default function Remediations({
   )
 
   const csafPath = `/vulnerabilities/${vulnerabilityIndex}/remediations`
-  const knownAffectedProducts = vulnerability.products.filter(
-    (p) => p.status === 'known_affected',
-  )
+  const knownAffectedProductIdSet = new Set(knownAffectedProductIds)
 
   return (
     <>
@@ -92,10 +102,7 @@ export default function Remediations({
             csafPath={`${csafPath}/${index}`}
             isTouched={isTouched}
             products={refs?.filter((p) =>
-              knownAffectedProducts.some(
-                (product) =>
-                  product.productId === p.full_product_name.product_id,
-              ),
+              knownAffectedProductIdSet.has(p.full_product_name.product_id),
             )}
             onChange={remediationsListState.updateDataEntry}
           />
@@ -140,6 +147,12 @@ function RemediationForm({
 }) {
   const { t } = useTranslation()
   const fieldValidation = useFieldValidation(`${csafPath}/product_ids`)
+  const productError = fieldValidation.hasErrors
+    ? fieldValidation.errorMessages[0].message
+    : ''
+  const applyAllKnownAffectedProducts =
+    remediation.applyAllKnownAffectedProducts ??
+    remediation.productIds.length === 0
 
   return (
     <VSplit>
@@ -198,18 +211,43 @@ function RemediationForm({
         isDisabled={checkReadOnly(remediation, 'url')}
         placeholder={getPlaceholder(remediation, 'url')}
       />
-      <ProductsTagList
-        error={
-          fieldValidation.hasErrors
-            ? fieldValidation.errorMessages[0].message
-            : ''
-        }
-        description={t('vulnerabilities.remediation.productsDescription')}
-        selected={remediation.productIds}
-        products={ptbs}
-        onChange={(productIds) => onChange({ ...remediation, productIds })}
-        isRequired
-      />
+      <Checkbox
+        isSelected={applyAllKnownAffectedProducts}
+        onChange={(event) => {
+          const isChecked = event.target.checked
+          onChange({
+            ...remediation,
+            applyAllKnownAffectedProducts: isChecked,
+            productIds: isChecked ? [] : remediation.productIds,
+          })
+        }}
+      >
+        {t('vulnerabilities.remediation.applyAllKnownAffectedProducts')}
+      </Checkbox>
+      {applyAllKnownAffectedProducts && productError && (
+        <p
+          className="text-danger-500 text-sm"
+          data-testid="products-hidden-error"
+        >
+          {productError}
+        </p>
+      )}
+      {!applyAllKnownAffectedProducts && (
+        <ProductsTagList
+          error={productError}
+          description={t('vulnerabilities.remediation.productsDescription')}
+          selected={remediation.productIds}
+          products={ptbs}
+          onChange={(productIds) =>
+            onChange({
+              ...remediation,
+              productIds,
+              applyAllKnownAffectedProducts: false,
+            })
+          }
+          isRequired
+        />
+      )}
     </VSplit>
   )
 }

--- a/src/routes/vulnerabilities/Scores.tsx
+++ b/src/routes/vulnerabilities/Scores.tsx
@@ -11,9 +11,9 @@ import {
 import { useFieldValidation } from '@/utils/validation/useFieldValidation'
 import { useListValidation } from '@/utils/validation/useListValidation'
 import { usePrefixValidation } from '@/utils/validation/usePrefixValidation'
-import { Alert, Chip } from '@heroui/react'
+import { Alert, Checkbox, Chip } from '@heroui/react'
 import { calculateBaseScore, calculateQualScore, parseVersion } from 'cvss4'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import ProductsTagList from './components/ProductsTagList'
 import { TVulnerability } from './types/tVulnerability'
@@ -37,6 +37,15 @@ export default function Scores({
   const { t } = useTranslation()
   const { getSelectableRefs } = useProductTreeBranch()
   const refs = getSelectableRefs()
+
+  const knownAffectedOrInvestigationProducts = useMemo(
+    () =>
+      vulnerability.products.filter(
+        (p) =>
+          p.status === 'known_affected' || p.status === 'under_investigation',
+      ),
+    [vulnerability.products],
+  )
   // The scores are sorted by CVSS version, so we can use the index to find the correct score
   const scoresListState = useListState<TVulnerabilityScore>({
     initialData: vulnerability.scores?.sort((a, b) =>
@@ -54,10 +63,6 @@ export default function Scores({
   const listValidation = useListValidation(
     `/vulnerabilities/${vulnerabilityIndex}/scores`,
     scoresListState.data,
-  )
-
-  const knownAffectedOrInvestigationProducts = vulnerability.products.filter(
-    (p) => p.status === 'known_affected' || p.status === 'under_investigation',
   )
 
   const getV3Index = (score: TVulnerabilityScore) => {
@@ -164,6 +169,11 @@ function ScoreForm({
   }
 
   const fieldValidation = useFieldValidation(`${csafPath}/products`)
+  const productError = fieldValidation.hasErrors
+    ? fieldValidation.errorMessages[0].message
+    : ''
+  const applyAllKnownAffectedProducts =
+    score.applyAllKnownAffectedProducts ?? score.productIds.length === 0
 
   const handleChange = (newValue: string) => {
     try {
@@ -234,17 +244,44 @@ function ScoreForm({
         isReadOnly={true}
       />
       {score.cvssVersion !== '4.0' && (
+        <Checkbox
+          isSelected={applyAllKnownAffectedProducts}
+          onChange={(event) => {
+            const isChecked = event.target.checked
+            onChange({
+              ...score,
+              applyAllKnownAffectedProducts: isChecked,
+              productIds: isChecked ? [] : score.productIds,
+            })
+          }}
+        >
+          {t('vulnerabilities.score.applyAllKnownAffectedProducts')}
+        </Checkbox>
+      )}
+      {score.cvssVersion !== '4.0' &&
+        applyAllKnownAffectedProducts &&
+        productError && (
+          <p
+            className="text-danger-500 text-sm"
+            data-testid="products-hidden-error"
+          >
+            {productError}
+          </p>
+        )}
+      {score.cvssVersion !== '4.0' && !applyAllKnownAffectedProducts && (
         <ProductsTagList
           isRequired
-          error={
-            fieldValidation.hasErrors
-              ? fieldValidation.errorMessages[0].message
-              : ''
-          }
+          error={productError}
           description={t('vulnerabilities.score.productsDescription')}
           selected={score.productIds}
           products={ptbs}
-          onChange={(productIds) => onChange({ ...score, productIds })}
+          onChange={(productIds) =>
+            onChange({
+              ...score,
+              productIds,
+              applyAllKnownAffectedProducts: false,
+            })
+          }
         />
       )}
     </VSplit>

--- a/src/routes/vulnerabilities/types/tRemediation.ts
+++ b/src/routes/vulnerabilities/types/tRemediation.ts
@@ -18,6 +18,7 @@ export type TRemediation = {
   date?: string
   url?: string
   productIds: string[]
+  applyAllKnownAffectedProducts?: boolean
 }
 
 export function useRemediationGenerator(): TRemediation {
@@ -30,5 +31,6 @@ export function useRemediationGenerator(): TRemediation {
     id: uid(),
     category: defaultRemediation.category || 'mitigation',
     productIds: [],
+    applyAllKnownAffectedProducts: true,
   }
 }

--- a/src/routes/vulnerabilities/types/tVulnerabilityScore.ts
+++ b/src/routes/vulnerabilities/types/tVulnerabilityScore.ts
@@ -7,6 +7,7 @@ export type TVulnerabilityScore = {
   cvssVersion: TCvssVersion
   vectorString: string
   productIds: string[]
+  applyAllKnownAffectedProducts?: boolean
 }
 
 export function getDefaultVulnerabilityScore(): TVulnerabilityScore {
@@ -15,5 +16,6 @@ export function getDefaultVulnerabilityScore(): TVulnerabilityScore {
     cvssVersion: null,
     vectorString: '',
     productIds: [],
+    applyAllKnownAffectedProducts: true,
   }
 }

--- a/src/utils/csafExport/csafExport.ts
+++ b/src/utils/csafExport/csafExport.ts
@@ -180,6 +180,15 @@ export function createCSAFDocument(
     },
     vulnerabilities: Object.values(documentStore.vulnerabilities).map(
       (vulnerability) => {
+        const knownAffectedProductIds = [
+          ...new Set(
+            vulnerability.products
+              .filter((product) => product.status === 'known_affected')
+              .map((product) => product.productId)
+              .filter((id): id is string => Boolean(id)),
+          ),
+        ]
+
         const productStatus = () => {
           const products = vulnerability.products
 
@@ -206,9 +215,13 @@ export function createCSAFDocument(
         const remediations = vulnerability.remediations?.map((remediation) => ({
           category: remediation.category,
           date: remediation.date || undefined,
-          details: remediation.details,
+          details: remediation.details || '',
           url: remediation.url || undefined,
-          product_ids: remediation.productIds,
+          product_ids:
+            (remediation.applyAllKnownAffectedProducts ??
+            remediation.productIds.length === 0)
+              ? knownAffectedProductIds
+              : remediation.productIds,
         }))
         const flags =
           vulnerability.flags?.map((flag) => ({
@@ -257,7 +270,7 @@ export function createCSAFDocument(
           product_status: productStatus(),
           flags: flags.length > 0 ? flags : undefined,
           remediations: remediations?.length > 0 ? remediations : undefined,
-          scores: parseScores(vulnerability.scores),
+          scores: parseScores(vulnerability.scores, knownAffectedProductIds),
         }
       },
     ),

--- a/src/utils/csafExport/parseScores.ts
+++ b/src/utils/csafExport/parseScores.ts
@@ -1,7 +1,10 @@
 import { TVulnerabilityScore } from '@/routes/vulnerabilities/types/tVulnerabilityScore'
 import { calculateBaseScore, calculateQualScore } from 'cvss4'
 
-export default function parseScores(scores: TVulnerabilityScore[]) {
+export default function parseScores(
+  scores: TVulnerabilityScore[],
+  knownAffectedProductIds: string[] = [],
+) {
   const v3scores = scores?.filter(
     (score) => score.cvssVersion === '3.0' || score.cvssVersion === '3.1',
   )
@@ -19,6 +22,12 @@ export default function parseScores(scores: TVulnerabilityScore[]) {
           // as there will be errors already in the vectorString
         }
 
+        const applyAllKnownAffectedProducts =
+          score.applyAllKnownAffectedProducts ?? score.productIds.length === 0
+        const products = applyAllKnownAffectedProducts
+          ? knownAffectedProductIds
+          : score.productIds
+
         return {
           cvss_v3: {
             version: score.cvssVersion,
@@ -26,7 +35,7 @@ export default function parseScores(scores: TVulnerabilityScore[]) {
             baseScore,
             baseSeverity,
           },
-          products: score.productIds,
+          products: [...new Set(products)],
         }
       })
     : undefined

--- a/src/utils/csafImport/parseVulnerabilities.ts
+++ b/src/utils/csafImport/parseVulnerabilities.ts
@@ -59,6 +59,7 @@ export function parseVulnerabilities(
           })) || [],
         remediations: vulnerability.remediations?.map((remediation) => {
           const defaultRemediation = remediationGenerator
+
           return {
             id: defaultRemediation.id,
             category: remediation.category ?? defaultRemediation.category,
@@ -66,6 +67,7 @@ export function parseVulnerabilities(
             details: remediation.details ?? defaultRemediation.details,
             url: remediation.url ?? defaultRemediation.url,
             productIds: remediation.product_ids,
+            applyAllKnownAffectedProducts: false,
           } as TRemediation
         }),
         scores: vulnerability.scores?.map((score) => {
@@ -86,6 +88,7 @@ export function parseVulnerabilities(
           return {
             id: defaultScore.id,
             productIds: score.products,
+            applyAllKnownAffectedProducts: false,
             cvssVersion: cvssInfos?.version ?? defaultScore.cvssVersion,
             vectorString: cvssInfos?.vectorString ?? defaultScore.vectorString,
           } as TVulnerabilityScore

--- a/tests/e2e/product-database-import.cy.js
+++ b/tests/e2e/product-database-import.cy.js
@@ -198,8 +198,6 @@ describe('Product Database Import', () => {
       .find('textarea')
       .click()
       .type('This is a test remediation')
-    cy.get('[placeholder="Add Product"]').first().click()
-    cy.contains('li', 'Vendor Name Product Name 1.0.0').click()
 
     cy.get('[data-slot="tab"]').contains('Scores').click()
     cy.contains('Add Score').click()
@@ -208,9 +206,6 @@ describe('Product Database Import', () => {
       .find('input')
       .click()
       .type('CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N')
-    cy.get('[placeholder="Add Product"]').first().click()
-    cy.wait(100)
-    cy.contains('li', 'Vendor Name Product Name 1.0.0').click()
 
     // Set history
     cy.contains('History').click()

--- a/tests/e2e/software-advisory-export.cy.js
+++ b/tests/e2e/software-advisory-export.cy.js
@@ -173,11 +173,8 @@ describe('Create a new software advisory & export it', () => {
       .find('textarea')
       .click()
       .type('This is a test remediation')
-    cy.get('[placeholder="Add Product"]').first().click()
-    cy.contains(
-      'li',
-      'Test Vendor Test Software 1.0.0 installed on Test Vendor Test Hardware 1.2.0',
-    ).click()
+
+    cy.wait(500)
 
     cy.get('[data-slot="tab"]').contains('Scores').click()
     cy.contains('Add Score').click()
@@ -186,12 +183,6 @@ describe('Create a new software advisory & export it', () => {
       .find('input')
       .click()
       .type('CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N')
-    cy.get('[placeholder="Add Product"]').first().click()
-    cy.wait(100)
-    cy.contains(
-      'li',
-      'Test Vendor Test Software 1.0.0 installed on Test Vendor Test Hardware 1.2.0',
-    ).click()
 
     // Set history
     cy.contains('History').click()

--- a/tests/routes/vulnerabilities/Remediations.test.tsx
+++ b/tests/routes/vulnerabilities/Remediations.test.tsx
@@ -159,7 +159,17 @@ vi.mock('@heroui/react', () => ({
     <div data-testid="alert" data-color={color} className={className}>
       {children}
     </div>
-  )
+  ),
+  Checkbox: ({ children, isSelected, onChange }: any) => (
+    <label data-testid="apply-known-affected-checkbox">
+      <input
+        type="checkbox"
+        checked={!!isSelected}
+        onChange={(e) => onChange?.(e)}
+      />
+      {children}
+    </label>
+  ),
 }))
 
 vi.mock('@heroui/select', () => ({
@@ -242,10 +252,10 @@ describe('Remediations', () => {
       {
         id: 'prod-1',
         productId: 'product1',
-        versions: ['product1'],
         status: 'known_affected'
       }
     ],
+    flags: [],
     remediations: [mockRemediation],
     scores: []
   }
@@ -297,11 +307,14 @@ describe('Remediations', () => {
 
     mockUseProductTreeBranch.mockReturnValue({
       rootBranch: mockPTBs,
+      families: [],
       findProductTreeBranch: vi.fn(),
       findProductTreeBranchWithParents: vi.fn(),
+      getFullProductName: vi.fn((id: string) => id),
+      getRelationshipFullProductName: vi.fn(() => ''),
       getFilteredPTBs: vi.fn(),
       getPTBsByCategory: vi.fn(),
-      getSelectablePTBs: () => mockPTBs,
+      getPTBName: vi.fn(() => ({ name: 'Product', isReadonly: false })),
       getSelectableRefs: vi.fn(() => [
         {
           category: 'product_version',
@@ -318,9 +331,13 @@ describe('Remediations', () => {
           }
         }
       ]),
+      getGroupedSelectableRefs: vi.fn(() => ({})),
       addPTB: vi.fn(),
+      addProductFamily: vi.fn(),
       updatePTB: vi.fn(),
-      deletePTB: vi.fn()
+      updateFamily: vi.fn(),
+      deletePTB: vi.fn(),
+      deleteFamily: vi.fn(),
     })
 
     mockUsePrefixValidation.mockReturnValue({
@@ -664,6 +681,46 @@ describe('Remediations', () => {
       expect(screen.getByTestId('products-error')).toHaveTextContent('At least one product is required')
     })
 
+    it('shows product validation error when apply-all hides product selector', () => {
+      mockUseFieldValidation.mockReturnValue({
+        messages: [{ path: '/productIds', message: 'At least one product is required' }],
+        hasErrors: true,
+        hasWarnings: false,
+        hasInfos: false,
+        errorMessages: [{ path: '/productIds', message: 'At least one product is required' }],
+        warningMessages: [],
+        infoMessages: [],
+        isTouched: true,
+        markFieldAsTouched: vi.fn()
+      })
+
+      const applyAllRemediation: TRemediation = {
+        ...mockRemediation,
+        productIds: [],
+        applyAllKnownAffectedProducts: true
+      }
+
+      mockUseListState.mockReturnValue({
+        data: [applyAllRemediation],
+        setData: mockSetData,
+        updateDataEntry: mockUpdateDataEntry,
+        addDataEntry: vi.fn(),
+        removeDataEntry: vi.fn(),
+        getId: vi.fn((entry) => entry.id)
+      })
+
+      render(
+        <Remediations
+          vulnerability={{ ...mockVulnerability, remediations: [applyAllRemediation] }}
+          vulnerabilityIndex={0}
+          onChange={mockOnChange}
+        />
+      )
+
+      expect(screen.queryByTestId('products-tag-list')).not.toBeInTheDocument()
+      expect(screen.getByTestId('products-hidden-error')).toHaveTextContent('At least one product is required')
+    })
+
     it('does not show validation errors when field is valid', () => {
       render(
         <Remediations
@@ -754,7 +811,6 @@ describe('Remediations', () => {
           {
             id: 'prod-1',
             productId: 'product1',
-            versions: ['product1'],
             status: 'known_not_affected' as const
           }
         ] as TVulnerabilityProduct[]

--- a/tests/routes/vulnerabilities/Scores.test.tsx
+++ b/tests/routes/vulnerabilities/Scores.test.tsx
@@ -97,6 +97,16 @@ vi.mock('@heroui/react', () => ({
       {children}
     </div>
   ),
+  Checkbox: ({ children, isSelected, onChange }: any) => (
+    <label data-testid="apply-known-affected-checkbox">
+      <input
+        type="checkbox"
+        checked={!!isSelected}
+        onChange={(e) => onChange?.(e)}
+      />
+      {children}
+    </label>
+  ),
   Chip: ({ children, color, variant, radius, size }: any) => (
     <div 
       data-testid="chip" 
@@ -198,16 +208,15 @@ describe('Scores Component', () => {
       {
         id: 'prod1',
         productId: 'product1',
-        versions: ['v1.0'],
         status: 'known_affected'
       },
       {
         id: 'prod2',
         productId: 'product2',
-        versions: ['v2.0'],
         status: 'under_investigation'
       }
     ],
+    flags: [],
     remediations: [],
     scores: []
   }
@@ -252,11 +261,14 @@ describe('Scores Component', () => {
     
     mockUseProductTreeBranch.mockReturnValue({
       rootBranch: mockProductTreeBranches,
+      families: [],
       findProductTreeBranch: vi.fn(),
       findProductTreeBranchWithParents: vi.fn(),
+      getFullProductName: vi.fn((id: string) => id),
+      getRelationshipFullProductName: vi.fn(() => ''),
       getFilteredPTBs: vi.fn(),
       getPTBsByCategory: vi.fn(),
-      getSelectablePTBs: vi.fn(() => mockProductTreeBranches),
+      getPTBName: vi.fn(() => ({ name: 'Product', isReadonly: false })),
       getSelectableRefs: vi.fn(() => [
         {
           category: 'product_version',
@@ -273,9 +285,13 @@ describe('Scores Component', () => {
           }
         }
       ]),
+      getGroupedSelectableRefs: vi.fn(() => ({})),
       addPTB: vi.fn(),
+      addProductFamily: vi.fn(),
       updatePTB: vi.fn(),
-      deletePTB: vi.fn()
+      updateFamily: vi.fn(),
+      deletePTB: vi.fn(),
+      deleteFamily: vi.fn(),
     })
     
     mockUseFieldValidation.mockReturnValue({
@@ -734,6 +750,45 @@ describe('Scores Component', () => {
       
       expect(screen.getByTestId('products-error')).toHaveTextContent('Products are required')
     })
+
+          it('shows product validation error when apply-all hides product selector', () => {
+            const onChange = vi.fn()
+            const applyAllScore = {
+              ...mockScore,
+              productIds: [],
+              applyAllKnownAffectedProducts: true,
+            }
+            const listStateWithScore = {
+              ...mockListState,
+              data: [applyAllScore]
+            }
+
+            mockUseListState.mockReturnValue(listStateWithScore)
+            mockUseFieldValidation.mockReturnValue({
+              hasErrors: true,
+              errorMessages: [
+                { path: '/vulnerabilities/0/scores/0/products', message: 'Products are required' }
+              ],
+              hasWarnings: false,
+              warningMessages: [],
+              hasInfos: false,
+              infoMessages: [],
+              isTouched: false,
+              markFieldAsTouched: vi.fn(),
+              messages: []
+            })
+
+            render(
+              <Scores
+                vulnerability={{ ...mockVulnerability, scores: [applyAllScore] }}
+                vulnerabilityIndex={0}
+                onChange={onChange}
+              />
+            )
+
+            expect(screen.queryByTestId('products-tag-list')).not.toBeInTheDocument()
+            expect(screen.getByTestId('products-hidden-error')).toHaveTextContent('Products are required')
+          })
 
     it('updates product IDs when ProductsTagList changes', async () => {
       const user = userEvent.setup()

--- a/tests/routes/vulnerabilities/types/tRemediation.test.ts
+++ b/tests/routes/vulnerabilities/types/tRemediation.test.ts
@@ -72,11 +72,13 @@ describe('tRemediation', () => {
         id: 'test-id',
         category: 'mitigation',
         productIds: ['prod1', 'prod2'],
+        applyAllKnownAffectedProducts: false,
       }
 
       expect(remediation.id).toBe('test-id')
       expect(remediation.category).toBe('mitigation')
       expect(remediation.productIds).toEqual(['prod1', 'prod2'])
+      expect(remediation.applyAllKnownAffectedProducts).toBe(false)
     })
 
     it('should support all optional fields', () => {
@@ -87,6 +89,7 @@ describe('tRemediation', () => {
         date: '2025-09-15',
         url: 'https://example.com/fix',
         productIds: ['prod1'],
+        applyAllKnownAffectedProducts: true,
       }
 
       expect(remediation.details).toBe('Detailed remediation information')
@@ -99,6 +102,7 @@ describe('tRemediation', () => {
         id: 'test-id',
         category: 'none_available',
         productIds: [],
+        applyAllKnownAffectedProducts: true,
       }
 
       expect(remediation.productIds).toEqual([])
@@ -110,6 +114,7 @@ describe('tRemediation', () => {
           id: `test-${category}`,
           category,
           productIds: [],
+          applyAllKnownAffectedProducts: true,
         }
         
         expect(remediation.category).toBe(category)
@@ -142,6 +147,7 @@ describe('tRemediation', () => {
         id: 'generated-unique-id',
         category: 'mitigation',
         productIds: [],
+        applyAllKnownAffectedProducts: true,
       })
     })
 
@@ -156,6 +162,7 @@ describe('tRemediation', () => {
         id: 'generated-unique-id',
         category: 'vendor_fix',
         productIds: [],
+        applyAllKnownAffectedProducts: true,
       })
     })
 
@@ -173,6 +180,7 @@ describe('tRemediation', () => {
         id: 'generated-unique-id',
         category: 'workaround',
         productIds: [],
+        applyAllKnownAffectedProducts: true,
         // Note: The function only uses category from template, not other fields
       })
     })
@@ -204,6 +212,7 @@ describe('tRemediation', () => {
         expect(result.category).toBe(category)
         expect(result.id).toBe(`id-for-${category}`)
         expect(result.productIds).toEqual([])
+        expect(result.applyAllKnownAffectedProducts).toBe(true)
       })
     })
 

--- a/tests/routes/vulnerabilities/types/tVulnerabilityScore.test.ts
+++ b/tests/routes/vulnerabilities/types/tVulnerabilityScore.test.ts
@@ -24,6 +24,7 @@ describe('tVulnerabilityScore Types and Functions', () => {
           cvssVersion: version,
           vectorString: 'test-vector',
           productIds: [],
+          applyAllKnownAffectedProducts: true,
         }
         expect(score.cvssVersion).toBe(version)
       })
@@ -52,6 +53,7 @@ describe('tVulnerabilityScore Types and Functions', () => {
         cvssVersion: '3.1',
         vectorString: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H',
         productIds: ['product-1', 'product-2'],
+        applyAllKnownAffectedProducts: false,
       }
 
       expect(score.id).toBe('test-id-123')
@@ -60,6 +62,7 @@ describe('tVulnerabilityScore Types and Functions', () => {
         'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H',
       )
       expect(score.productIds).toEqual(['product-1', 'product-2'])
+      expect(score.applyAllKnownAffectedProducts).toBe(false)
     })
 
     it('should handle empty arrays and null values', () => {
@@ -68,6 +71,7 @@ describe('tVulnerabilityScore Types and Functions', () => {
         cvssVersion: null,
         vectorString: '',
         productIds: [],
+        applyAllKnownAffectedProducts: true,
       }
 
       expect(score.id).toBe('empty-test')
@@ -85,6 +89,7 @@ describe('tVulnerabilityScore Types and Functions', () => {
         vectorString:
           'CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N',
         productIds: manyProductIds,
+        applyAllKnownAffectedProducts: false,
       }
 
       expect(score.productIds).toEqual(manyProductIds)
@@ -97,6 +102,7 @@ describe('tVulnerabilityScore Types and Functions', () => {
         cvssVersion: '3.0',
         vectorString: 'CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H',
         productIds: ['product-test'],
+        applyAllKnownAffectedProducts: false,
       }
 
       expect(score).toHaveProperty('id')
@@ -119,6 +125,7 @@ describe('tVulnerabilityScore Types and Functions', () => {
         cvssVersion: null,
         vectorString: '',
         productIds: [],
+        applyAllKnownAffectedProducts: true,
       })
     })
 

--- a/tests/utils/csafExport/csafExport.test.ts
+++ b/tests/utils/csafExport/csafExport.test.ts
@@ -121,8 +121,8 @@ describe('csafExport', () => {
           name: 'Test Application v1.0.0 on Linux',
         },
       ],
-      vulnerabilities: {
-        'vuln-1': {
+      vulnerabilities: [
+        {
           id: 'vuln-1',
           cve: 'CVE-2023-12345',
           title: 'Cross-site Scripting Vulnerability',
@@ -177,7 +177,7 @@ describe('csafExport', () => {
             },
           ],
         },
-      },
+      ],
       families: [],
       importedCSAFDocument: {},
       setImportedCSAFDocument: vi.fn(),
@@ -261,7 +261,7 @@ describe('csafExport', () => {
     }
     minimalStore.products = {} as any
     minimalStore.relationships = []
-    minimalStore.vulnerabilities = {} as any
+    minimalStore.vulnerabilities = []
 
     const result = createCSAFDocument(
       minimalStore,
@@ -279,8 +279,8 @@ describe('csafExport', () => {
   it('should handle vulnerabilities without optional fields', () => {
     const storeWithBasicVuln = createMockDocumentStore()
 
-    storeWithBasicVuln.vulnerabilities = {
-      'basic-vuln': {
+    storeWithBasicVuln.vulnerabilities = [
+      {
         id: 'basic-vuln',
         cve: undefined,
         title: 'Basic Vulnerability',
@@ -291,7 +291,7 @@ describe('csafExport', () => {
         remediations: undefined,
         scores: [],
       },
-    } as any
+    ]
 
     const result = createCSAFDocument(
       storeWithBasicVuln,
@@ -308,7 +308,7 @@ describe('csafExport', () => {
 
   it('should export user vulnerability references and CVSS v4 references', () => {
     const mockStore = createMockDocumentStore()
-    mockStore.vulnerabilities['vuln-1'].references = [
+    mockStore.vulnerabilities[0].references = [
       {
         id: 'vuln-ref-1',
         summary: 'Vendor Security Advisory',
@@ -345,7 +345,7 @@ describe('csafExport', () => {
 
   it('should deduplicate vulnerability references when they match generated CVSS v4 references', () => {
     const mockStore = createMockDocumentStore()
-    mockStore.vulnerabilities['vuln-1'].references = [
+    mockStore.vulnerabilities[0].references = [
       {
         id: 'vuln-ref-1',
         summary: 'CVSS v4.0 Score',
@@ -365,6 +365,58 @@ describe('csafExport', () => {
     )
 
     expect(result.vulnerabilities[0].references).toHaveLength(1)
+  })
+
+  it('applies known affected products to remediations and scores when enabled', () => {
+    const mockStore = createMockDocumentStore()
+    mockStore.vulnerabilities[0].products = [
+      {
+        id: 'vuln-product-1',
+        productId: 'version-1',
+        status: 'known_affected',
+      },
+      {
+        id: 'vuln-product-2',
+        productId: 'version-2',
+        status: 'fixed',
+      },
+    ] as any
+
+    mockStore.vulnerabilities[0].remediations = [
+      {
+        category: 'mitigation',
+        details: 'Update to latest version',
+        productIds: [],
+        applyAllKnownAffectedProducts: true,
+      },
+    ] as any
+
+    mockStore.vulnerabilities[0].scores = [
+      {
+        id: 'score-1',
+        cvssVersion: '3.1',
+        vectorString: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N',
+        productIds: [],
+        applyAllKnownAffectedProducts: true,
+      },
+    ] as any
+
+    const result = createCSAFDocument(
+      mockStore,
+      mockGetFullProductName,
+      mockGetRelationshipFullProductName,
+      {
+        template: {},
+        productDatabase: { enabled: false },
+      },
+    )
+
+    expect(result.vulnerabilities[0].remediations?.[0].product_ids).toEqual([
+      'version-1',
+    ])
+    expect(result.vulnerabilities[0].scores?.[0].products).toEqual([
+      'version-1',
+    ])
   })
 
   describe('createCSAFExportFilename', () => {

--- a/tests/utils/csafImport/parseVulnerabilities.test.ts
+++ b/tests/utils/csafImport/parseVulnerabilities.test.ts
@@ -496,7 +496,8 @@ describe('parseVulnerabilities', () => {
         date: '2023-01-01',
         details: 'Update to version 1.2.3',
         url: 'https://example.com/fix',
-        productIds: ['product-1']
+        productIds: ['product-1'],
+        applyAllKnownAffectedProducts: false,
       })
       expect(result[0].remediations[1]).toEqual({
         id: mockRemediationGenerator.id,
@@ -504,7 +505,8 @@ describe('parseVulnerabilities', () => {
         date: '2023-01-02',
         details: 'Disable feature X',
         url: 'https://example.com/workaround',
-        productIds: ['product-2']
+        productIds: ['product-2'],
+        applyAllKnownAffectedProducts: false,
       })
     })
 
@@ -540,7 +542,8 @@ describe('parseVulnerabilities', () => {
         date: mockRemediationGenerator.date,
         details: mockRemediationGenerator.details,
         url: mockRemediationGenerator.url,
-        productIds: ['product-1']
+        productIds: ['product-1'],
+        applyAllKnownAffectedProducts: false,
       })
     })
 
@@ -614,6 +617,7 @@ describe('parseVulnerabilities', () => {
       expect(result[0].scores[0]).toEqual({
         id: mockDefaultScore.id,
         productIds: ['product-1'],
+        applyAllKnownAffectedProducts: false,
         cvssVersion: '3.1',
         vectorString: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H'
       })
@@ -648,6 +652,7 @@ describe('parseVulnerabilities', () => {
       expect(result[0].scores[0]).toEqual({
         id: mockDefaultScore.id,
         productIds: ['product-1'],
+        applyAllKnownAffectedProducts: false,
         cvssVersion: '4.0',
         vectorString: 'CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N'
       })
@@ -679,6 +684,7 @@ describe('parseVulnerabilities', () => {
       expect(result[0].scores[0]).toEqual({
         id: mockDefaultScore.id,
         productIds: ['product-1'],
+        applyAllKnownAffectedProducts: false,
         cvssVersion: mockDefaultScore.cvssVersion,
         vectorString: mockDefaultScore.vectorString
       })
@@ -710,6 +716,7 @@ describe('parseVulnerabilities', () => {
       expect(result[0].scores[0]).toEqual({
         id: mockDefaultScore.id,
         productIds: ['product-1'],
+        applyAllKnownAffectedProducts: false,
         cvssVersion: mockDefaultScore.cvssVersion,
         vectorString: mockDefaultScore.vectorString
       })
@@ -1007,6 +1014,7 @@ describe('parseVulnerabilities', () => {
       expect(result[0].scores[0]).toEqual({
         id: mockDefaultScore.id,
         productIds: ['product-1'],
+        applyAllKnownAffectedProducts: false,
         cvssVersion: mockDefaultScore.cvssVersion,
         vectorString: mockDefaultScore.vectorString
       })


### PR DESCRIPTION
…remediations/scores

## What type of PR is this?

- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description

This PR adds a default-enabled "Apply all known affected products" behavior for vulnerability remediations and CVSS scores.

When enabled, product selection is hidden in the UI and CSAF export automatically resolves products from the vulnerability's `known_affected` product status list.

## Manual test instructions
1. Create a vulnerability and add at least:
   - one product with status `Known Affected`
   - one product with another status (for contrast).
2. Go to **Remediations**, add a remediation.
3. Verify the checkbox **Apply all known affected products** is checked by default.
4. Verify product picker is hidden while checked.
5. Uncheck it and verify the product picker appears.
6. Re-check it and verify picker hides again.
7. Repeat steps 2-6 in **Scores** for a CVSS v3 score.
8. Trigger a product validation error and verify:
   - when picker is visible, error appears on the picker
   - when apply-all is checked (picker hidden), error appears below the checkbox.
9. Export CSAF and verify:
   - remediation `product_ids` contains all vulnerability `known_affected` product IDs when apply-all is enabled
   - CVSS v3 score `products` contains all vulnerability `known_affected` product IDs when apply-all is enabled.
10. Import CSAF and ensure known affected checkbox is not applied.

## Related Tickets & Documents
- Closes #101 
