### PR TITLE
increase the width of the vulnerability product matrix

### DIFF
--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -8,7 +8,7 @@ export default function ProgressBar({
   progress: number
 }) {
   return (
-    <div className="relative mb-5 flex justify-stretch px-8 pb-1">
+    <div className="relative mb-5 flex max-w-5xl justify-stretch px-8 pb-1">
       {sections.map((section, i) => (
         <Fragment key={i}>
           <ProgressBarItem

--- a/src/components/WizardStep.tsx
+++ b/src/components/WizardStep.tsx
@@ -15,6 +15,7 @@ export type WizardStepProps = PropsWithChildren<{
   onContinue?: string | (() => void)
   continueLabel?: string
   noContentWrapper?: boolean
+  style?: React.CSSProperties
 }>
 
 export default function WizardStep({
@@ -27,12 +28,13 @@ export default function WizardStep({
   continueLabel,
   children,
   noContentWrapper,
+  style,
 }: WizardStepProps) {
   const navigate = useNavigate()
   const { t } = useTranslation()
 
   return (
-    <div className="flex max-w-5xl flex-col gap-4 p-8">
+    <div className="flex max-w-5xl flex-col gap-4 p-8" style={style}>
       <ProgressBar
         sections={[
           t('nav.document'),

--- a/src/routes/vulnerabilities/ProductMatrix.tsx
+++ b/src/routes/vulnerabilities/ProductMatrix.tsx
@@ -108,6 +108,7 @@ export default function ProductMatrix() {
       progress={3}
       onBack="/vulnerabilities/list"
       onContinue="/tracking"
+      style={{ maxWidth: 'calc(100svw - 240px)' }}
     >
       <p className="text-default-500 text-sm">
         {t('vulnerabilities.matrix.description')}

--- a/tests/components/__snapshots__/ProgressBar.test.tsx.snap
+++ b/tests/components/__snapshots__/ProgressBar.test.tsx.snap
@@ -2,13 +2,13 @@
 
 exports[`ProgressBar > should handle empty sections array 1`] = `
 <div
-  class="relative mb-5 flex justify-stretch px-8 pb-1"
+  class="relative mb-5 flex max-w-5xl justify-stretch px-8 pb-1"
 />
 `;
 
 exports[`ProgressBar > should handle negative progress 1`] = `
 <div
-  class="relative mb-5 flex justify-stretch px-8 pb-1"
+  class="relative mb-5 flex max-w-5xl justify-stretch px-8 pb-1"
 >
   <div
     class="flex flex-col items-center justify-center gap-2"
@@ -95,7 +95,7 @@ exports[`ProgressBar > should handle negative progress 1`] = `
 
 exports[`ProgressBar > should handle progress greater than sections length 1`] = `
 <div
-  class="relative mb-5 flex justify-stretch px-8 pb-1"
+  class="relative mb-5 flex max-w-5xl justify-stretch px-8 pb-1"
 >
   <div
     class="flex flex-col items-center justify-center gap-2"
@@ -182,7 +182,7 @@ exports[`ProgressBar > should handle progress greater than sections length 1`] =
 
 exports[`ProgressBar > should render progress bar with all sections 1`] = `
 <div
-  class="relative mb-5 flex justify-stretch px-8 pb-1"
+  class="relative mb-5 flex max-w-5xl justify-stretch px-8 pb-1"
 >
   <div
     class="flex flex-col items-center justify-center gap-2"
@@ -269,7 +269,7 @@ exports[`ProgressBar > should render progress bar with all sections 1`] = `
 
 exports[`ProgressBar > should render with full progress 1`] = `
 <div
-  class="relative mb-5 flex justify-stretch px-8 pb-1"
+  class="relative mb-5 flex max-w-5xl justify-stretch px-8 pb-1"
 >
   <div
     class="flex flex-col items-center justify-center gap-2"
@@ -356,7 +356,7 @@ exports[`ProgressBar > should render with full progress 1`] = `
 
 exports[`ProgressBar > should render with no progress 1`] = `
 <div
-  class="relative mb-5 flex justify-stretch px-8 pb-1"
+  class="relative mb-5 flex max-w-5xl justify-stretch px-8 pb-1"
 >
   <div
     class="flex flex-col items-center justify-center gap-2"
@@ -443,7 +443,7 @@ exports[`ProgressBar > should render with no progress 1`] = `
 
 exports[`ProgressBar > should render with partial progress 1`] = `
 <div
-  class="relative mb-5 flex justify-stretch px-8 pb-1"
+  class="relative mb-5 flex max-w-5xl justify-stretch px-8 pb-1"
 >
   <div
     class="flex flex-col items-center justify-center gap-2"
@@ -530,7 +530,7 @@ exports[`ProgressBar > should render with partial progress 1`] = `
 
 exports[`ProgressBar > should render with single section 1`] = `
 <div
-  class="relative mb-5 flex justify-stretch px-8 pb-1"
+  class="relative mb-5 flex max-w-5xl justify-stretch px-8 pb-1"
 >
   <div
     class="flex flex-col items-center justify-center gap-2"


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
The width of the vulnerability is increased to use the full width of the screen.

<img width="2528" height="884" alt="Screenshot 2026-04-28 at 11 02 05" src="https://github.com/user-attachments/assets/6b1ab7c1-06d9-41a6-a6cf-6fde1cf678eb" />

## Related Tickets & Documents

- Closes #228
