### PR TITLE
fix the import hidden field message

### DIFF
--- a/src/utils/csafImport/scheme.ts
+++ b/src/utils/csafImport/scheme.ts
@@ -22,6 +22,18 @@ const IdentificationHelper = {
   skus: ['string'],
 }
 
+const ProductTreeBranchSchema: JSONObject = {
+  category: 'string',
+  name: 'string',
+  product: {
+    name: 'string',
+    product_id: 'string',
+    product_identification_helper: IdentificationHelper,
+  },
+}
+
+ProductTreeBranchSchema.branches = [ProductTreeBranchSchema]
+
 export default {
   document: {
     lang: 'string',
@@ -92,41 +104,7 @@ export default {
   },
 
   product_tree: {
-    branches: [
-      // Vendors
-      {
-        category: 'string',
-        name: 'string',
-
-        product: {
-          product_identification_helper: IdentificationHelper,
-        },
-        branches: [
-          // Product Names
-          {
-            category: 'string',
-            name: 'string',
-            product: {
-              name: 'string',
-              product_id: 'string',
-              product_identification_helper: IdentificationHelper,
-            },
-            branches: [
-              // Product Versions
-              {
-                category: 'string',
-                name: 'string',
-                product: {
-                  name: 'string',
-                  product_id: 'string',
-                  product_identification_helper: IdentificationHelper,
-                },
-              },
-            ],
-          },
-        ],
-      },
-    ],
+    branches: [ProductTreeBranchSchema],
     relationships: [
       {
         category: 'string',


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation Update

## Description
Made the CSAF import schema for product_tree.branches recursive so deeper valid branch nesting is no longer incorrectly reported as hidden fields.
Results in fewer false-positive hidden-field warnings during CSAF import for nested product trees.

## Related Tickets & Documents

- Closes #229 